### PR TITLE
WIP support for detail pages from services

### DIFF
--- a/app/schemas/io.sweers.catchup.data.CatchUpDatabase/3.json
+++ b/app/schemas/io.sweers.catchup.data.CatchUpDatabase/3.json
@@ -1,0 +1,242 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "41d9d2a0a29eb7753bc6e6c10493dbe8",
+    "entities": [
+      {
+        "tableName": "pages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `type` TEXT NOT NULL, `expiration` INTEGER NOT NULL, `page` TEXT NOT NULL, `sessionId` INTEGER NOT NULL, `items` TEXT NOT NULL, `nextPageToken` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiration",
+            "columnName": "expiration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "page",
+            "columnName": "page",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "items",
+            "columnName": "items",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nextPageToken",
+            "columnName": "nextPageToken",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `title` TEXT NOT NULL, `timestamp` INTEGER, `score` TEXT, `tag` TEXT, `author` TEXT, `source` TEXT, `itemClickUrl` TEXT, `detailKey` TEXT, `value` TEXT, `type` TEXT, `url` TEXT, `animatable` INTEGER, `sourceUrl` TEXT, `bestSize` TEXT, `imageId` TEXT, `text` TEXT, `textPrefix` TEXT, `icon` INTEGER, `clickUrl` TEXT, `iconTintColor` INTEGER, `formatTextAsCount` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "itemClickUrl",
+            "columnName": "itemClickUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "detailKey",
+            "columnName": "detailKey",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "summarizationInfo.value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "summarizationInfo.type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageInfo.url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageInfo.animatable",
+            "columnName": "animatable",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageInfo.sourceUrl",
+            "columnName": "sourceUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageInfo.bestSize",
+            "columnName": "bestSize",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageInfo.imageId",
+            "columnName": "imageId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mark.text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mark.textPrefix",
+            "columnName": "textPrefix",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mark.icon",
+            "columnName": "icon",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mark.clickUrl",
+            "columnName": "clickUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mark.iconTintColor",
+            "columnName": "iconTintColor",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mark.formatTextAsCount",
+            "columnName": "formatTextAsCount",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "smmryEntries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`url` TEXT NOT NULL, `json` TEXT NOT NULL, PRIMARY KEY(`url`))",
+        "fields": [
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "json",
+            "columnName": "json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "url"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '41d9d2a0a29eb7753bc6e6c10493dbe8')"
+    ]
+  }
+}

--- a/app/src/main/kotlin/io/sweers/catchup/data/CatchUpDatabase.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/data/CatchUpDatabase.kt
@@ -33,7 +33,8 @@ import org.threeten.bp.Instant
       CatchUpItem::class,
       SmmryStorageEntry::class
     ],
-    version = 2)
+    version = 3
+)
 @TypeConverters(CatchUpConverters::class)
 abstract class CatchUpDatabase : RoomDatabase() {
 

--- a/app/src/main/kotlin/io/sweers/catchup/ui/DetailDisplayer.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/ui/DetailDisplayer.kt
@@ -16,9 +16,20 @@
 package io.sweers.catchup.ui
 
 import androidx.fragment.app.FragmentManager
+import me.saket.inboxrecyclerview.InboxRecyclerView
 import me.saket.inboxrecyclerview.page.ExpandablePageLayout
 
 interface DetailDisplayer {
   val isExpandedOrExpanding: Boolean
+
+  /**
+   * Shows a detail activity given an available page and fragmentmanager.
+   */
   fun showDetail(body: (ExpandablePageLayout, FragmentManager) -> () -> Unit)
+
+  /**
+   * Binds (via [InboxRecyclerView.expandablePage] an irv to the available page only, does nothing
+   * with fragmentmanagers. Used mostly for state restoration.
+   */
+  fun bindOnly(irv: InboxRecyclerView)
 }

--- a/app/src/main/kotlin/io/sweers/catchup/ui/DetailDisplayer.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/ui/DetailDisplayer.kt
@@ -15,6 +15,7 @@
  */
 package io.sweers.catchup.ui
 
+import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import me.saket.inboxrecyclerview.InboxRecyclerView
 import me.saket.inboxrecyclerview.page.ExpandablePageLayout
@@ -28,8 +29,24 @@ interface DetailDisplayer {
   fun showDetail(body: (ExpandablePageLayout, FragmentManager) -> () -> Unit)
 
   /**
-   * Binds (via [InboxRecyclerView.expandablePage] an irv to the available page only, does nothing
+   * Binds (via [InboxRecyclerView.expandablePage] an irv to the available page/fragment only,
+   * does nothing with [FragmentManager]. Used mostly for state restoration.
+   *
+   * If [useExistingFragment], it should be resolved from a [FragmentManager] and call through to
+   * [bind] with the result.
+   */
+  fun bind(irv: InboxRecyclerView, useExistingFragment: Boolean = false)
+
+  /**
+   * Binds (via [InboxRecyclerView.expandablePage] an irv to the available page/fragment only,
+   * does nothing with [FragmentManager]. Used mostly for state restoration. [bind] can call this,
+   * but this should not call [bind].
+   */
+  fun bind(irv: InboxRecyclerView, targetFragment: Fragment?)
+
+  /**
+   * Unbinds (via [InboxRecyclerView.expandablePage] from an irv to the available page only, does nothing
    * with fragmentmanagers. Used mostly for state restoration.
    */
-  fun bindOnly(irv: InboxRecyclerView)
+  fun unbind(irv: InboxRecyclerView)
 }

--- a/app/src/main/kotlin/io/sweers/catchup/ui/DetailDisplayer.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/ui/DetailDisplayer.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2019. Zac Sweers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.sweers.catchup.ui
+
+import androidx.fragment.app.FragmentManager
+import me.saket.inboxrecyclerview.page.ExpandablePageLayout
+
+interface DetailDisplayer {
+  val isExpandedOrExpanding: Boolean
+  fun showDetail(body: (ExpandablePageLayout, FragmentManager) -> () -> Unit)
+}

--- a/app/src/main/kotlin/io/sweers/catchup/ui/activity/MainActivity.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/ui/activity/MainActivity.kt
@@ -177,8 +177,8 @@ class MainActivityDetailDisplayer @Inject constructor(
     // TODO this is ugly, do better
     detailPage.pushParentToolbarOnExpand((mainActivity.supportFragmentManager.findFragmentById(R.id.fragment_container) as PagerFragment).toolbar)
     detailPage.addStateChangeCallbacks(object : SimplePageStateChangeCallbacks() {
-      override fun onPageCollapsed(page: ExpandablePageLayout) {
-        page.removeStateChangeCallbacks(this)
+      override fun onPageCollapsed() {
+        detailPage.removeStateChangeCallbacks(this)
         collapser = null
       }
     })

--- a/app/src/main/kotlin/io/sweers/catchup/ui/activity/MainActivity.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/ui/activity/MainActivity.kt
@@ -172,6 +172,9 @@ class MainActivityDetailDisplayer @Inject constructor(
   override fun showDetail(body: (ExpandablePageLayout, FragmentManager) -> () -> Unit) {
     collapser?.invoke()
     collapser = null
+
+    // TODO this is ugly, do better
+    detailPage.pushParentToolbarOnExpand((mainActivity.supportFragmentManager.findFragmentById(R.id.fragment_container) as PagerFragment).toolbar)
     detailPage.addStateChangeCallbacks(object : SimplePageStateChangeCallbacks() {
       override fun onPageCollapsed() {
         detailPage.removeStateChangeCallbacks(this)

--- a/app/src/main/kotlin/io/sweers/catchup/ui/activity/MainActivity.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/ui/activity/MainActivity.kt
@@ -42,6 +42,7 @@ import io.sweers.catchup.ui.fragments.PagerFragment
 import io.sweers.catchup.ui.fragments.service.StorageBackedService
 import io.sweers.catchup.util.customtabs.CustomTabActivityHelper
 import kotterknife.bindView
+import me.saket.inboxrecyclerview.InboxRecyclerView
 import me.saket.inboxrecyclerview.page.ExpandablePageLayout
 import me.saket.inboxrecyclerview.page.SimplePageStateChangeCallbacks
 import javax.inject.Inject
@@ -176,11 +177,15 @@ class MainActivityDetailDisplayer @Inject constructor(
     // TODO this is ugly, do better
     detailPage.pushParentToolbarOnExpand((mainActivity.supportFragmentManager.findFragmentById(R.id.fragment_container) as PagerFragment).toolbar)
     detailPage.addStateChangeCallbacks(object : SimplePageStateChangeCallbacks() {
-      override fun onPageCollapsed() {
-        detailPage.removeStateChangeCallbacks(this)
+      override fun onPageCollapsed(page: ExpandablePageLayout) {
+        page.removeStateChangeCallbacks(this)
         collapser = null
       }
     })
     collapser = body(detailPage, mainActivity.supportFragmentManager)
+  }
+
+  override fun bindOnly(irv: InboxRecyclerView) {
+    irv.expandablePage = detailPage
   }
 }

--- a/app/src/main/kotlin/io/sweers/catchup/ui/activity/MainActivityFragmentFactory.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/ui/activity/MainActivityFragmentFactory.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2019 Zac Sweers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sweers.catchup.ui.activity
+
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentFactory
+import io.sweers.catchup.injection.scopes.PerActivity
+import javax.inject.Inject
+import javax.inject.Provider
+
+@PerActivity
+class MainActivityFragmentFactory @Inject constructor(
+    private val providers: Map<Class<out Fragment>, @JvmSuppressWildcards Provider<Fragment>>
+) : FragmentFactory() {
+  override fun instantiate(classLoader: ClassLoader, className: String): Fragment {
+    val fragmentClass = classLoader.loadClass(className)
+    return providers[fragmentClass]?.get() ?: super.instantiate(classLoader, className)
+  }
+}

--- a/app/src/main/kotlin/io/sweers/catchup/ui/activity/MainActivityFragmentFactory.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/ui/activity/MainActivityFragmentFactory.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2019 Zac Sweers
+ * Copyright (C) 2019. Zac Sweers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.sweers.catchup.ui.activity
 
 import androidx.fragment.app.Fragment
@@ -24,7 +23,7 @@ import javax.inject.Provider
 
 @PerActivity
 class MainActivityFragmentFactory @Inject constructor(
-    private val providers: Map<Class<out Fragment>, @JvmSuppressWildcards Provider<Fragment>>
+  private val providers: Map<Class<out Fragment>, @JvmSuppressWildcards Provider<Fragment>>
 ) : FragmentFactory() {
   override fun instantiate(classLoader: ClassLoader, className: String): Fragment {
     val fragmentClass = classLoader.loadClass(className)

--- a/app/src/main/kotlin/io/sweers/catchup/ui/base/BaseActivity.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/ui/base/BaseActivity.kt
@@ -144,7 +144,6 @@ abstract class BaseActivity : AppCompatActivity(), LifecycleScopeProvider<Activi
    * super.onCreate() is called.
    */
   open fun setFragmentFactory() {
-
   }
 
   @CallSuper

--- a/app/src/main/kotlin/io/sweers/catchup/ui/base/BaseActivity.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/ui/base/BaseActivity.kt
@@ -134,8 +134,17 @@ abstract class BaseActivity : AppCompatActivity(), LifecycleScopeProvider<Activi
   @CallSuper
   override fun onCreate(savedInstanceState: Bundle?) {
     AndroidInjection.inject(this)
+    setFragmentFactory()
     super.onCreate(savedInstanceState)
     lifecycleRelay.accept(CREATE)
+  }
+
+  /**
+   * Exists as a hook to allow subclasses to inject a FragmentFactory before
+   * super.onCreate() is called.
+   */
+  open fun setFragmentFactory() {
+
   }
 
   @CallSuper

--- a/app/src/main/kotlin/io/sweers/catchup/ui/fragments/PagerFragment.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/ui/fragments/PagerFragment.kt
@@ -100,7 +100,7 @@ class PagerFragment : InjectingBaseFragment() {
   private val rootLayout by bindView<CoordinatorLayout>(R.id.pager_fragment_root)
   private val tabLayout by bindView<TabLayout>(R.id.tab_layout)
   private val viewPager by bindView<ViewPager>(R.id.view_pager)
-  private val toolbar by bindView<Toolbar>(R.id.toolbar)
+  internal val toolbar by bindView<Toolbar>(R.id.toolbar)
   private val appBarLayout by bindView<AppBarLayout>(R.id.appbarlayout)
 
   private val argbEvaluator = ArgbEvaluator()

--- a/app/src/main/kotlin/io/sweers/catchup/ui/fragments/PagerFragment.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/ui/fragments/PagerFragment.kt
@@ -100,8 +100,8 @@ class PagerFragment : InjectingBaseFragment() {
   private val rootLayout by bindView<CoordinatorLayout>(R.id.pager_fragment_root)
   private val tabLayout by bindView<TabLayout>(R.id.tab_layout)
   private val viewPager by bindView<ViewPager>(R.id.view_pager)
-  internal val toolbar by bindView<Toolbar>(R.id.toolbar)
-  private val appBarLayout by bindView<AppBarLayout>(R.id.appbarlayout)
+  private val toolbar by bindView<Toolbar>(R.id.toolbar)
+  val appBarLayout by bindView<AppBarLayout>(R.id.appbarlayout)
 
   private val argbEvaluator = ArgbEvaluator()
   private var statusBarColorAnimator: ValueAnimator? = null

--- a/app/src/main/kotlin/io/sweers/catchup/ui/fragments/SmmryFragment.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/ui/fragments/SmmryFragment.kt
@@ -52,6 +52,7 @@ import io.sweers.catchup.data.smmry.model.SmmryResponse
 import io.sweers.catchup.data.smmry.model.Success
 import io.sweers.catchup.data.smmry.model.SummarizationError
 import io.sweers.catchup.data.smmry.model.UnknownErrorCode
+import io.sweers.catchup.service.api.ScrollableContent
 import io.sweers.catchup.service.api.SummarizationInfo
 import io.sweers.catchup.service.api.SummarizationType
 import io.sweers.catchup.service.api.SummarizationType.NONE
@@ -69,7 +70,7 @@ import javax.inject.Inject
 /**
  * Overlay fragment for displaying Smmry API results.
  */
-class SmmryFragment : InjectableBaseFragment() {
+class SmmryFragment : InjectableBaseFragment(), ScrollableContent {
 
   companion object {
     private const val ID_TITLE = "smmryfragment.title"
@@ -192,7 +193,7 @@ class SmmryFragment : InjectableBaseFragment() {
     }
   }
 
-  fun canScrollVertically(directionInt: Int): Boolean {
+  override fun canScrollVertically(directionInt: Int): Boolean {
     return content.canScrollVertically(directionInt)
   }
 

--- a/app/src/main/kotlin/io/sweers/catchup/ui/fragments/service/ServiceFragment.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/ui/fragments/service/ServiceFragment.kt
@@ -90,7 +90,6 @@ import kotterknife.bindView
 import kotterknife.onClick
 import me.saket.inboxrecyclerview.InboxRecyclerView
 import me.saket.inboxrecyclerview.dimming.TintPainter
-import me.saket.inboxrecyclerview.page.ExpandablePageLayout
 import me.saket.inboxrecyclerview.page.InterceptResult
 import me.saket.inboxrecyclerview.page.SimplePageStateChangeCallbacks
 import retrofit2.HttpException
@@ -285,7 +284,7 @@ class ServiceFragment : InjectingBaseFragment(),
                   }
                 }
                 page.addStateChangeCallbacks(object : SimplePageStateChangeCallbacks() {
-                  override fun onPageCollapsed(page: ExpandablePageLayout) {
+                  override fun onPageCollapsed() {
                     detailDisplayed = false
                     page.pullToCollapseInterceptor = null
                     page.removeStateChangeCallbacks(this)

--- a/app/src/main/kotlin/io/sweers/catchup/ui/fragments/service/ServiceFragment.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/ui/fragments/service/ServiceFragment.kt
@@ -260,7 +260,10 @@ class ServiceFragment : InjectingBaseFragment(),
         )
         if (BuildConfig.DEBUG) {
           item.detailKey?.let { key ->
-            val args = bundleOf("detailKey" to key)
+            val args = bundleOf(
+                "detailKey" to key,
+                "detailTitle" to item.title
+            )
             val targetProvider = fragmentCreators[service.meta().deeplinkFragment] ?: error("No deeplink for $key")
             holder.setLongClickHandler {
               detailDisplayer.showDetail { page, fragmentManager ->

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -31,5 +31,9 @@
       tools:context=".ui.activity.MainActivity"
       />
 
-  <!-- We have a nested level here because we'll potentially add new detail pages on top of the existing container here -->
+  <me.saket.inboxrecyclerview.page.ExpandablePageLayout
+      android:id="@+id/detailPage"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      />
 </FrameLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -18,9 +18,18 @@
 <FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/fragment_container"
+    android:id="@+id/root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
-    tools:context=".ui.activity.MainActivity"
-    />
+    >
+
+  <FrameLayout
+      android:id="@+id/fragment_container"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      tools:context=".ui.activity.MainActivity"
+      />
+
+  <!-- We have a nested level here because we'll potentially add new detail pages on top of the existing container here -->
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_service.xml
+++ b/app/src/main/res/layout/fragment_service.xml
@@ -44,12 +44,6 @@
 
   </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
-  <me.saket.inboxrecyclerview.page.ExpandablePageLayout
-      android:id="@+id/smmrypage"
-      android:layout_width="match_parent"
-      android:layout_height="match_parent"
-      />
-
   <ProgressBar
       android:id="@+id/progress"
       android:layout_width="wrap_content"

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -19,5 +19,4 @@
   <item name="background" type="id"/>
   <item name="image" type="id"/>
   <item name="glide_target" type="id"/>
-  <item name="detailPage" type="id"/>
 </resources>

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -19,4 +19,5 @@
   <item name="background" type="id"/>
   <item name="image" type="id"/>
   <item name="glide_target" type="id"/>
+  <item name="detailPage" type="id"/>
 </resources>

--- a/buildSrc/src/main/kotlin/dependencies.kt
+++ b/buildSrc/src/main/kotlin/dependencies.kt
@@ -357,7 +357,7 @@ object deps {
 
     const val flick = "me.saket:flick:1.4.0"
     const val gestureViews = "com.alexvasilkov:gesture-views:2.2.0"
-    const val inboxRecyclerView = "me.saket:inboxrecyclerview:2.0.0-20190805.042255-10"
+    const val inboxRecyclerView = "me.saket:inboxrecyclerview:2.0.0-beta1"
     const val javaxInject = "org.glassfish:javax.annotation:10.0-b28"
     const val jsoup = "org.jsoup:jsoup:1.12.1"
     const val jsr305 = "com.google.code.findbugs:jsr305:3.0.2"

--- a/buildSrc/src/main/kotlin/dependencies.kt
+++ b/buildSrc/src/main/kotlin/dependencies.kt
@@ -101,6 +101,13 @@ object deps {
       const val fragment = "androidx.fragment:fragment:$fragmentVersion"
       const val fragmentKtx = "androidx.fragment:fragment-ktx:$fragmentVersion"
 
+      object viewModel {
+        private const val version = "2.2.0-alpha03"
+        const val core = "androidx.lifecycle:lifecycle-viewmodel:$version"
+        const val ktx = "androidx.lifecycle:lifecycle-viewmodel-ktx:$version"
+        const val savedState = "androidx.lifecycle:lifecycle-viewmodel-savedstate:1.0.0-alpha03"
+      }
+
       const val viewPager = "androidx.viewpager:viewpager:1.0.0"
       const val swipeRefresh = "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0-alpha02"
       const val palette = "androidx.palette:palette:1.0.0"
@@ -116,6 +123,11 @@ object deps {
         const val apt = "androidx.lifecycle:lifecycle-compiler:$version"
         const val extensions = "androidx.lifecycle:lifecycle-extensions:$version"
         const val ktx = "androidx.lifecycle:lifecycle-runtime-ktx:$version"
+      }
+
+      object liveData {
+        private const val version = "2.2.0-alpha01"
+        const val ktx = "androidx.lifecycle:lifecycle-livedata-ktx:$version"
       }
 
       object room {
@@ -151,6 +163,12 @@ object deps {
     const val httpcache = "com.apollographql.apollo:apollo-http-cache:${versions.apollo}"
     const val runtime = "com.apollographql.apollo:apollo-runtime:${versions.apollo}"
     const val rx2Support = "com.apollographql.apollo:apollo-rx2-support:${versions.apollo}"
+  }
+
+  object assistedInject {
+    private const val version = "0.5.0"
+    const val annotations = "com.squareup.inject:assisted-inject-annotations-dagger2:$version"
+    const val processor = "com.squareup.inject:assisted-inject-processor-dagger2:$version"
   }
 
   object auto {

--- a/buildSrc/src/main/kotlin/dependencies.kt
+++ b/buildSrc/src/main/kotlin/dependencies.kt
@@ -339,7 +339,7 @@ object deps {
 
     const val flick = "me.saket:flick:1.4.0"
     const val gestureViews = "com.alexvasilkov:gesture-views:2.2.0"
-    const val inboxRecyclerView = "me.saket:inboxrecyclerview:1.0.0-rc1"
+    const val inboxRecyclerView = "me.saket:inboxrecyclerview:2.0.0-20190805.042255-10"
     const val javaxInject = "org.glassfish:javax.annotation:10.0-b28"
     const val jsoup = "org.jsoup:jsoup:1.12.1"
     const val jsr305 = "com.google.code.findbugs:jsr305:3.0.2"

--- a/libraries/util/src/main/kotlin/io/sweers/catchup/util/ViewExt.kt
+++ b/libraries/util/src/main/kotlin/io/sweers/catchup/util/ViewExt.kt
@@ -23,6 +23,7 @@ import android.content.Context
 import android.content.res.Configuration
 import android.os.Build
 import android.view.View
+import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import androidx.interpolator.view.animation.FastOutSlowInInterpolator
 import androidx.interpolator.view.animation.LinearOutSlowInInterpolator
@@ -66,6 +67,9 @@ fun View.clearLightNavBar() {
 }
 
 inline fun View.show(animate: Boolean = false) {
+  if (isVisible) {
+    return
+  }
   if (animate) {
     alpha = 0F
     visibility = View.VISIBLE
@@ -93,7 +97,10 @@ inline infix fun View.showIf(condition: Boolean) {
 }
 
 inline fun View.hide(animate: Boolean = false) {
-  if (animate) {
+  if (!isVisible) {
+    return
+  }
+  if (animate && !isInvisible) {
     animate()
         .setDuration(300)
         .setInterpolator(LinearOutSlowInInterpolator())

--- a/service-api/src/main/kotlin/io/sweers/catchup/service/api/CatchUpItem.kt
+++ b/service-api/src/main/kotlin/io/sweers/catchup/service/api/CatchUpItem.kt
@@ -34,7 +34,8 @@ data class CatchUpItem(
   val itemClickUrl: String? = null,
   @Embedded val summarizationInfo: SummarizationInfo? = null,
   @Embedded val imageInfo: ImageInfo? = null,
-  @Embedded val mark: Mark? = null
+  @Embedded val mark: Mark? = null,
+  val detailKey: String? = null
 ) : DisplayableItem {
 
   override fun stableId() = id

--- a/service-api/src/main/kotlin/io/sweers/catchup/service/api/FragmentKey.kt
+++ b/service-api/src/main/kotlin/io/sweers/catchup/service/api/FragmentKey.kt
@@ -15,22 +15,12 @@
  */
 package io.sweers.catchup.service.api
 
-import androidx.annotation.ColorRes
-import androidx.annotation.DrawableRes
-import androidx.annotation.StringRes
 import androidx.fragment.app.Fragment
+import dagger.MapKey
+import kotlin.annotation.AnnotationRetention.BINARY
+import kotlin.reflect.KClass
 
-data class ServiceMeta(
-  val id: String,
-  @StringRes val name: Int,
-  @ColorRes val themeColor: Int,
-  @DrawableRes val icon: Int,
-  val isVisual: Boolean = false,
-  val firstPageKey: String,
-  val pagesAreNumeric: Boolean = false,
-  val serviceConfiguration: ServiceConfiguration? = null,
-  val enabled: Boolean = true,
-  val deeplinkFragment: Class<out Fragment>? = null
-) {
-  val enabledPreferenceKey = "service_config_${id}_enabled"
-}
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
+@Retention(value = BINARY)
+@MapKey
+annotation class FragmentKey(val value: KClass<out Fragment>)

--- a/service-api/src/main/kotlin/io/sweers/catchup/service/api/ScrollableContent.kt
+++ b/service-api/src/main/kotlin/io/sweers/catchup/service/api/ScrollableContent.kt
@@ -15,22 +15,6 @@
  */
 package io.sweers.catchup.service.api
 
-import androidx.annotation.ColorRes
-import androidx.annotation.DrawableRes
-import androidx.annotation.StringRes
-import androidx.fragment.app.Fragment
-
-data class ServiceMeta(
-  val id: String,
-  @StringRes val name: Int,
-  @ColorRes val themeColor: Int,
-  @DrawableRes val icon: Int,
-  val isVisual: Boolean = false,
-  val firstPageKey: String,
-  val pagesAreNumeric: Boolean = false,
-  val serviceConfiguration: ServiceConfiguration? = null,
-  val enabled: Boolean = true,
-  val deeplinkFragment: Class<out Fragment>? = null
-) {
-  val enabledPreferenceKey = "service_config_${id}_enabled"
+interface ScrollableContent {
+  fun canScrollVertically(directionInt: Int): Boolean
 }

--- a/services/hackernews/build.gradle.kts
+++ b/services/hackernews/build.gradle.kts
@@ -82,6 +82,8 @@ dependencies {
 
   implementation(deps.android.firebase.database)
 
+  api(deps.android.androidx.design)
+  api(deps.android.androidx.fragmentKtx)
   api(deps.android.androidx.annotations)
   api(deps.dagger.runtime)
   api(deps.misc.lazythreeten)

--- a/services/hackernews/build.gradle.kts
+++ b/services/hackernews/build.gradle.kts
@@ -79,7 +79,12 @@ dependencies {
   kapt(project(":service-registry:service-registry-compiler"))
   kapt(deps.crumb.compiler)
   kapt(deps.dagger.apt.compiler)
+  kapt(deps.assistedInject.processor)
+  compileOnly(deps.assistedInject.annotations)
 
+  implementation(deps.android.androidx.viewModel.core)
+  implementation(deps.android.androidx.viewModel.ktx)
+  implementation(deps.android.androidx.viewModel.savedState)
   implementation(deps.android.firebase.database)
 
   api(deps.android.androidx.design)

--- a/services/hackernews/src/main/kotlin/io/sweers/catchup/service/hackernews/HackerNewsCommentsFragment.kt
+++ b/services/hackernews/src/main/kotlin/io/sweers/catchup/service/hackernews/HackerNewsCommentsFragment.kt
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2019. Zac Sweers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.sweers.catchup.service.hackernews
+
+import android.os.Bundle
+import android.text.Html
+import android.text.SpannableString
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ProgressBar
+import android.widget.TextView
+import androidx.appcompat.widget.Toolbar
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.google.firebase.database.DataSnapshot
+import com.google.firebase.database.DatabaseError
+import com.google.firebase.database.FirebaseDatabase
+import com.google.firebase.database.ValueEventListener
+import io.sweers.catchup.service.api.ScrollableContent
+import io.sweers.catchup.service.hackernews.model.HackerNewsComment
+import io.sweers.catchup.service.hackernews.model.HackerNewsStory
+import io.sweers.catchup.util.d
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import kotlin.LazyThreadSafetyMode.NONE
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+class HackerNewsCommentsFragment @Inject constructor(
+  private val database: FirebaseDatabase
+) : Fragment(), ScrollableContent {
+
+  companion object {
+    const val ARG_DETAIL_KEY = "detailKey"
+    const val ARG_DETAIL_TITLE = "detailTitle"
+  }
+
+  private val list by lazy(NONE) { view!!.findViewById<RecyclerView>(R.id.list) }
+  private val progress by lazy(NONE) { view!!.findViewById<ProgressBar>(R.id.progress) }
+  private val toolbar by lazy(NONE) { view!!.findViewById<Toolbar>(R.id.toolbar) }
+  private val storyId by lazy(NONE) { arguments!!.getString(ARG_DETAIL_KEY)!! }
+
+  override fun onCreateView(
+    inflater: LayoutInflater,
+    container: ViewGroup?,
+    savedInstanceState: Bundle?
+  ): View? {
+    return inflater.inflate(R.layout.hacker_news_story, container, false)
+  }
+
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    super.onViewCreated(view, savedInstanceState)
+    toolbar.title = arguments?.getString(ARG_DETAIL_TITLE) ?: "Untitled"
+
+    viewLifecycleOwner.lifecycleScope.launch {
+      val (story, comments) = withContext(Dispatchers.IO) { loadComments() }
+
+      toolbar.title = story.title
+      val adapter = CommentsAdapter(comments)
+      list.adapter = adapter
+      list.layoutManager = LinearLayoutManager(view.context)
+      progress.visibility = View.GONE
+      list.visibility = View.VISIBLE
+    }
+  }
+
+  override fun canScrollVertically(directionInt: Int): Boolean {
+    return list.canScrollVertically(directionInt)
+  }
+
+  private suspend fun loadComments(): Pair<HackerNewsStory, List<HackerNewsComment>> {
+    val story = loadStory(storyId)
+
+    return story to story.kids!!.asFlow()
+        .map { loadItem(it.toString()) }
+        .toList()
+  }
+
+  private suspend fun loadStory(id: String) = suspendCancellableCoroutine<HackerNewsStory> { cont ->
+    val ref = database.getReference("v0/item/$id")
+    val listener = object : ValueEventListener {
+      override fun onDataChange(dataSnapshot: DataSnapshot) {
+        try {
+          ref.removeEventListener(this)
+          cont.resume(HackerNewsStory.create(dataSnapshot))
+        } catch (e: Exception) {
+          cont.resumeWithException(e)
+        }
+      }
+
+      override fun onCancelled(firebaseError: DatabaseError) {
+        d { "${firebaseError.code}" }
+        cont.resumeWithException(firebaseError.toException())
+      }
+    }
+    cont.invokeOnCancellation { ref.removeEventListener(listener) }
+    ref.addValueEventListener(listener)
+  }
+
+  private suspend fun loadItem(id: String) = suspendCancellableCoroutine<HackerNewsComment> { cont ->
+    val ref = database.getReference("v0/item/$id")
+    val listener = object : ValueEventListener {
+      override fun onDataChange(dataSnapshot: DataSnapshot) {
+        try {
+          ref.removeEventListener(this)
+          cont.resume(HackerNewsComment.create(dataSnapshot))
+        } catch (e: Exception) {
+          cont.resumeWithException(e)
+        }
+      }
+
+      override fun onCancelled(firebaseError: DatabaseError) {
+        d { "${firebaseError.code}" }
+        cont.resumeWithException(firebaseError.toException())
+      }
+    }
+    cont.invokeOnCancellation { ref.removeEventListener(listener) }
+    ref.addValueEventListener(listener)
+  }
+
+  private class CommentsAdapter(
+    private val comments: List<HackerNewsComment>
+  ) : RecyclerView.Adapter<CommentViewHolder>() {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CommentViewHolder {
+      return CommentViewHolder(TextView(parent.context))
+    }
+
+    override fun getItemCount(): Int {
+      return comments.size
+    }
+
+    override fun onBindViewHolder(holder: CommentViewHolder, position: Int) {
+      holder.textView.text = comments[position].text.let { Html.fromHtml(it) } ?: SpannableString("wtf this is null")
+    }
+  }
+
+  private class CommentViewHolder(val textView: TextView) : RecyclerView.ViewHolder(textView)
+}

--- a/services/hackernews/src/main/kotlin/io/sweers/catchup/service/hackernews/HackerNewsCommentsFragment.kt
+++ b/services/hackernews/src/main/kotlin/io/sweers/catchup/service/hackernews/HackerNewsCommentsFragment.kt
@@ -109,7 +109,10 @@ internal class HackerNewsCommentsFragment @Inject constructor(
 
     override fun onBindViewHolder(holder: CommentViewHolder, position: Int) {
       holder.textView.text = try {
-        comments[position].text.let { Html.fromHtml(it) }
+        comments[position].text.let {
+          @Suppress("DEPRECATION") // I don't know what I'm supposed to replace this with?
+          Html.fromHtml(it)
+        }
       } catch (e: NullPointerException) {
         "This kills the html: ${comments[position].text}"
       }

--- a/services/hackernews/src/main/kotlin/io/sweers/catchup/service/hackernews/HackerNewsCommentsFragment.kt
+++ b/services/hackernews/src/main/kotlin/io/sweers/catchup/service/hackernews/HackerNewsCommentsFragment.kt
@@ -98,7 +98,9 @@ class HackerNewsCommentsFragment @Inject constructor(
   }
 
   private suspend fun loadStory(id: String) = suspendCancellableCoroutine<HackerNewsStory> { cont ->
-    val ref = database.getReference("v0/item/$id")
+    val ref = database.getReference("v0/item/$id").apply {
+      keepSynced(true)
+    }
     val listener = object : ValueEventListener {
       override fun onDataChange(dataSnapshot: DataSnapshot) {
         try {
@@ -119,7 +121,9 @@ class HackerNewsCommentsFragment @Inject constructor(
   }
 
   private suspend fun loadItem(id: String) = suspendCancellableCoroutine<HackerNewsComment> { cont ->
-    val ref = database.getReference("v0/item/$id")
+    val ref = database.getReference("v0/item/$id").apply {
+      keepSynced(true)
+    }
     val listener = object : ValueEventListener {
       override fun onDataChange(dataSnapshot: DataSnapshot) {
         try {

--- a/services/hackernews/src/main/kotlin/io/sweers/catchup/service/hackernews/HackerNewsCommentsFragment.kt
+++ b/services/hackernews/src/main/kotlin/io/sweers/catchup/service/hackernews/HackerNewsCommentsFragment.kt
@@ -17,7 +17,6 @@ package io.sweers.catchup.service.hackernews
 
 import android.os.Bundle
 import android.text.Html
-import android.text.SpannableString
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -152,7 +151,11 @@ class HackerNewsCommentsFragment @Inject constructor(
     }
 
     override fun onBindViewHolder(holder: CommentViewHolder, position: Int) {
-      holder.textView.text = comments[position].text.let { Html.fromHtml(it) } ?: SpannableString("wtf this is null")
+      holder.textView.text = try {
+        comments[position].text.let { Html.fromHtml(it) }
+      } catch (e: NullPointerException) {
+        "This kills the html: ${comments[position].text}"
+      }
     }
   }
 

--- a/services/hackernews/src/main/kotlin/io/sweers/catchup/service/hackernews/HackerNewsCommentsFragment.kt
+++ b/services/hackernews/src/main/kotlin/io/sweers/catchup/service/hackernews/HackerNewsCommentsFragment.kt
@@ -24,31 +24,25 @@ import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import com.google.firebase.database.DataSnapshot
-import com.google.firebase.database.DatabaseError
-import com.google.firebase.database.FirebaseDatabase
-import com.google.firebase.database.ValueEventListener
 import io.sweers.catchup.service.api.ScrollableContent
+import io.sweers.catchup.service.hackernews.FragmentViewModelFactoryModule.ViewModelProviderFactoryInstantiator
+import io.sweers.catchup.service.hackernews.HackerNewsCommentsViewModel.State.Failure
+import io.sweers.catchup.service.hackernews.HackerNewsCommentsViewModel.State.Loading
+import io.sweers.catchup.service.hackernews.HackerNewsCommentsViewModel.State.Success
 import io.sweers.catchup.service.hackernews.model.HackerNewsComment
-import io.sweers.catchup.service.hackernews.model.HackerNewsStory
-import io.sweers.catchup.util.d
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.toList
+import io.sweers.catchup.util.hide
+import io.sweers.catchup.util.show
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlinx.coroutines.withContext
+import kotterknife.bindView
 import javax.inject.Inject
-import kotlin.LazyThreadSafetyMode.NONE
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
 
-class HackerNewsCommentsFragment @Inject constructor(
-  private val database: FirebaseDatabase
+internal class HackerNewsCommentsFragment @Inject constructor(
+  viewModelFactoryInstantiator: ViewModelProviderFactoryInstantiator
 ) : Fragment(), ScrollableContent {
 
   companion object {
@@ -56,10 +50,10 @@ class HackerNewsCommentsFragment @Inject constructor(
     const val ARG_DETAIL_TITLE = "detailTitle"
   }
 
-  private val list by lazy(NONE) { view!!.findViewById<RecyclerView>(R.id.list) }
-  private val progress by lazy(NONE) { view!!.findViewById<ProgressBar>(R.id.progress) }
-  private val toolbar by lazy(NONE) { view!!.findViewById<Toolbar>(R.id.toolbar) }
-  private val storyId by lazy(NONE) { arguments!!.getString(ARG_DETAIL_KEY)!! }
+  private val list by bindView<RecyclerView>(R.id.list)
+  private val progress by bindView<ProgressBar>(R.id.progress)
+  private val toolbar by bindView<Toolbar>(R.id.toolbar)
+  private val viewModel: HackerNewsCommentsViewModel by viewModels { viewModelFactoryInstantiator.create(this) }
 
   override fun onCreateView(
     inflater: LayoutInflater,
@@ -74,73 +68,32 @@ class HackerNewsCommentsFragment @Inject constructor(
     toolbar.title = arguments?.getString(ARG_DETAIL_TITLE) ?: "Untitled"
 
     viewLifecycleOwner.lifecycleScope.launch {
-      val (story, comments) = withContext(Dispatchers.IO) { loadComments() }
+      viewModel.viewState.collect { state ->
+        when (state) {
+          is Loading -> {
+            progress.show(true)
+            list.hide(true)
+          }
+          is Failure -> {
+            toolbar.title = "Failed to load :(. ${state.error.message}"
+          }
+          is Success -> {
+            val (story, comments) = state.data
 
-      toolbar.title = story.title
-      val adapter = CommentsAdapter(comments)
-      list.adapter = adapter
-      list.layoutManager = LinearLayoutManager(view.context)
-      progress.visibility = View.GONE
-      list.visibility = View.VISIBLE
+            toolbar.title = story.title
+            val adapter = CommentsAdapter(comments)
+            list.adapter = adapter
+            list.layoutManager = LinearLayoutManager(view.context)
+            progress.hide(true)
+            list.show(true)
+          }
+        }
+      }
     }
   }
 
   override fun canScrollVertically(directionInt: Int): Boolean {
     return list.canScrollVertically(directionInt)
-  }
-
-  private suspend fun loadComments(): Pair<HackerNewsStory, List<HackerNewsComment>> {
-    val story = loadStory(storyId)
-
-    return story to story.kids!!.asFlow()
-        .map { loadItem(it.toString()) }
-        .toList()
-  }
-
-  private suspend fun loadStory(id: String) = suspendCancellableCoroutine<HackerNewsStory> { cont ->
-    val ref = database.getReference("v0/item/$id").apply {
-      keepSynced(true)
-    }
-    val listener = object : ValueEventListener {
-      override fun onDataChange(dataSnapshot: DataSnapshot) {
-        try {
-          ref.removeEventListener(this)
-          cont.resume(HackerNewsStory.create(dataSnapshot))
-        } catch (e: Exception) {
-          cont.resumeWithException(e)
-        }
-      }
-
-      override fun onCancelled(firebaseError: DatabaseError) {
-        d { "${firebaseError.code}" }
-        cont.resumeWithException(firebaseError.toException())
-      }
-    }
-    cont.invokeOnCancellation { ref.removeEventListener(listener) }
-    ref.addValueEventListener(listener)
-  }
-
-  private suspend fun loadItem(id: String) = suspendCancellableCoroutine<HackerNewsComment> { cont ->
-    val ref = database.getReference("v0/item/$id").apply {
-      keepSynced(true)
-    }
-    val listener = object : ValueEventListener {
-      override fun onDataChange(dataSnapshot: DataSnapshot) {
-        try {
-          ref.removeEventListener(this)
-          cont.resume(HackerNewsComment.create(dataSnapshot))
-        } catch (e: Exception) {
-          cont.resumeWithException(e)
-        }
-      }
-
-      override fun onCancelled(firebaseError: DatabaseError) {
-        d { "${firebaseError.code}" }
-        cont.resumeWithException(firebaseError.toException())
-      }
-    }
-    cont.invokeOnCancellation { ref.removeEventListener(listener) }
-    ref.addValueEventListener(listener)
   }
 
   private class CommentsAdapter(

--- a/services/hackernews/src/main/kotlin/io/sweers/catchup/service/hackernews/HackerNewsCommentsViewModel.kt
+++ b/services/hackernews/src/main/kotlin/io/sweers/catchup/service/hackernews/HackerNewsCommentsViewModel.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2019. Zac Sweers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.sweers.catchup.service.hackernews
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.firebase.database.DataSnapshot
+import com.google.firebase.database.DatabaseError
+import com.google.firebase.database.FirebaseDatabase
+import com.google.firebase.database.ValueEventListener
+import com.squareup.inject.assisted.Assisted
+import com.squareup.inject.assisted.AssistedInject
+import io.sweers.catchup.service.hackernews.HackerNewsCommentsViewModel.State.Success
+import io.sweers.catchup.service.hackernews.model.HackerNewsComment
+import io.sweers.catchup.service.hackernews.model.HackerNewsStory
+import io.sweers.catchup.service.hackernews.viewmodelbits.ViewModelAssistedFactory
+import io.sweers.catchup.util.d
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.ConflatedBroadcastChannel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+internal class HackerNewsCommentsViewModel @AssistedInject constructor(
+  @Assisted private val savedState: SavedStateHandle,
+  private val database: FirebaseDatabase
+) : ViewModel() {
+
+  sealed class State {
+    object Loading : State()
+    class Success(val data: Pair<HackerNewsStory, List<HackerNewsComment>>) : State()
+    class Failure(val error: Throwable) : State()
+  }
+
+  private val storyId = savedState.get<String>(HackerNewsCommentsFragment.ARG_DETAIL_KEY)!!
+
+  val viewState: Flow<State> = ConflatedBroadcastChannel<State>(State.Loading).apply {
+    viewModelScope.launch {
+      try {
+        val result = withContext(Dispatchers.IO) {
+          Success(loadComments())
+        }
+        offer(result)
+      } catch (exception: Exception) {
+        offer(State.Failure(exception))
+      }
+    }
+  }.asFlow()
+
+  private suspend fun loadComments(): Pair<HackerNewsStory, List<HackerNewsComment>> {
+    val story = loadStory(storyId)
+
+    return story to story.kids!!.asFlow()
+        .map { loadItem(it.toString()) }
+        .toList()
+  }
+
+  private suspend fun loadStory(id: String) = suspendCancellableCoroutine<HackerNewsStory> { cont ->
+    val ref = database.getReference("v0/item/$id").apply {
+      keepSynced(true)
+    }
+    val listener = object : ValueEventListener {
+      override fun onDataChange(dataSnapshot: DataSnapshot) {
+        try {
+          ref.removeEventListener(this)
+          cont.resume(HackerNewsStory.create(dataSnapshot))
+        } catch (e: Exception) {
+          cont.resumeWithException(e)
+        }
+      }
+
+      override fun onCancelled(firebaseError: DatabaseError) {
+        d { "${firebaseError.code}" }
+        cont.resumeWithException(firebaseError.toException())
+      }
+    }
+    cont.invokeOnCancellation { ref.removeEventListener(listener) }
+    ref.addValueEventListener(listener)
+  }
+
+  private suspend fun loadItem(id: String) = suspendCancellableCoroutine<HackerNewsComment> { cont ->
+    val ref = database.getReference("v0/item/$id").apply {
+      keepSynced(true)
+    }
+    val listener = object : ValueEventListener {
+      override fun onDataChange(dataSnapshot: DataSnapshot) {
+        try {
+          ref.removeEventListener(this)
+          cont.resume(HackerNewsComment.create(dataSnapshot))
+        } catch (e: Exception) {
+          cont.resumeWithException(e)
+        }
+      }
+
+      override fun onCancelled(firebaseError: DatabaseError) {
+        d { "${firebaseError.code}" }
+        cont.resumeWithException(firebaseError.toException())
+      }
+    }
+    cont.invokeOnCancellation { ref.removeEventListener(listener) }
+    ref.addValueEventListener(listener)
+  }
+
+  @AssistedInject.Factory
+  interface Factory : ViewModelAssistedFactory<HackerNewsCommentsViewModel>
+}

--- a/services/hackernews/src/main/kotlin/io/sweers/catchup/service/hackernews/HackerNewsService.kt
+++ b/services/hackernews/src/main/kotlin/io/sweers/catchup/service/hackernews/HackerNewsService.kt
@@ -18,7 +18,6 @@ package io.sweers.catchup.service.hackernews
 import androidx.fragment.app.Fragment
 import com.google.firebase.database.DataSnapshot
 import com.google.firebase.database.DatabaseError
-import com.google.firebase.database.DatabaseException
 import com.google.firebase.database.FirebaseDatabase
 import com.google.firebase.database.ValueEventListener
 import dagger.Binds
@@ -78,7 +77,9 @@ internal class HackerNewsService @Inject constructor(
             }
           }
 
-          val ref = database.get().getReference("v0/topstories")
+          val ref = database.get().getReference("v0/topstories").apply {
+            keepSynced(true)
+          }
           emitter.setCancellable { ref.removeEventListener(listener) }
           ref.addValueEventListener(listener)
         }
@@ -192,13 +193,6 @@ abstract class HackerNewsModule {
     @Provides
     @JvmStatic
     internal fun provideDataBase(): FirebaseDatabase =
-        FirebaseDatabase.getInstance("https://hacker-news.firebaseio.com/").apply {
-          try {
-            setPersistenceEnabled(true)
-          } catch (e: DatabaseException) {
-            // Ignore, firebase doesn't give us a way to check if it's already been initialized
-            // because its API is *the worst*.
-          }
-        }
+        FirebaseDatabase.getInstance("https://hacker-news.firebaseio.com/")
   }
 }

--- a/services/hackernews/src/main/kotlin/io/sweers/catchup/service/hackernews/HackerNewsService.kt
+++ b/services/hackernews/src/main/kotlin/io/sweers/catchup/service/hackernews/HackerNewsService.kt
@@ -18,6 +18,7 @@ package io.sweers.catchup.service.hackernews
 import androidx.fragment.app.Fragment
 import com.google.firebase.database.DataSnapshot
 import com.google.firebase.database.DatabaseError
+import com.google.firebase.database.DatabaseException
 import com.google.firebase.database.FirebaseDatabase
 import com.google.firebase.database.ValueEventListener
 import dagger.Binds
@@ -190,7 +191,14 @@ abstract class HackerNewsModule {
 
     @Provides
     @JvmStatic
-    internal fun provideDataBase() =
-        FirebaseDatabase.getInstance("https://hacker-news.firebaseio.com/")
+    internal fun provideDataBase(): FirebaseDatabase =
+        FirebaseDatabase.getInstance("https://hacker-news.firebaseio.com/").apply {
+          try {
+            setPersistenceEnabled(true)
+          } catch (e: DatabaseException) {
+            // Ignore, firebase doesn't give us a way to check if it's already been initialized
+            // because its API is *the worst*.
+          }
+        }
   }
 }

--- a/services/hackernews/src/main/kotlin/io/sweers/catchup/service/hackernews/HackerNewsService.kt
+++ b/services/hackernews/src/main/kotlin/io/sweers/catchup/service/hackernews/HackerNewsService.kt
@@ -15,6 +15,7 @@
  */
 package io.sweers.catchup.service.hackernews
 
+import androidx.fragment.app.Fragment
 import com.google.firebase.database.DataSnapshot
 import com.google.firebase.database.DatabaseError
 import com.google.firebase.database.FirebaseDatabase
@@ -30,6 +31,7 @@ import io.reactivex.SingleEmitter
 import io.sweers.catchup.service.api.CatchUpItem
 import io.sweers.catchup.service.api.DataRequest
 import io.sweers.catchup.service.api.DataResult
+import io.sweers.catchup.service.api.FragmentKey
 import io.sweers.catchup.service.api.Mark.Companion.createCommentMark
 import io.sweers.catchup.service.api.Service
 import io.sweers.catchup.service.api.ServiceException
@@ -117,9 +119,12 @@ internal class HackerNewsService @Inject constructor(
                 itemClickUrl = url,
                 summarizationInfo = SummarizationInfo.from(url),
                 mark = kids?.size?.let {
-                  createCommentMark(count = it,
-                      clickUrl = "https://news.ycombinator.com/item?id=$id")
-                }
+                  createCommentMark(
+                      count = it,
+                      clickUrl = "https://news.ycombinator.com/item?id=$id"
+                  )
+                },
+                detailKey = id.toString()
             )
           }
         }
@@ -160,7 +165,8 @@ abstract class HackerNewsMetaModule {
         R.color.hnAccent,
         R.drawable.logo_hn,
         pagesAreNumeric = true,
-        firstPageKey = "0"
+        firstPageKey = "0",
+        deeplinkFragment = HackerNewsCommentsFragment::class.java
     )
   }
 }
@@ -173,6 +179,11 @@ abstract class HackerNewsModule {
   @ServiceKey(SERVICE_KEY)
   @Binds
   internal abstract fun hackerNewsService(hackerNewsService: HackerNewsService): Service
+
+  @Binds
+  @IntoMap
+  @FragmentKey(HackerNewsCommentsFragment::class)
+  abstract fun bindHnFragment(mainFragment: HackerNewsCommentsFragment): Fragment
 
   @Module
   companion object {

--- a/services/hackernews/src/main/kotlin/io/sweers/catchup/service/hackernews/model/HackerNewsStory.kt
+++ b/services/hackernews/src/main/kotlin/io/sweers/catchup/service/hackernews/model/HackerNewsStory.kt
@@ -75,3 +75,51 @@ internal data class HackerNewsStory(
     }
   }
 }
+
+// DataSnapshot { key = 20516882, value = {parent=20516063, by=frou_dh, id=20516882, text=stuff, time=1563986039, type=comment} }
+@Keep
+@NoArg
+internal data class HackerNewsComment(
+  val by: String,
+//  val dead: Boolean,
+  val deleted: Boolean,
+//  val descendants: Int,
+  val id: Long,
+  val kids: List<Long>?,
+  val parent: Long?,
+//  val parts: List<String>?,
+//  val score: Int,
+    /* private, but Firebase is too dumb to read private fields */
+  val time: Long?,
+//  val title: String?,
+  val text: String,
+    /* private, but Firebase is too dumb to read private fields */
+  val type: String?
+//  val url: String?
+) : HasStableId {
+
+  @Exclude
+  override fun stableId() = id
+
+  /*
+   * Excluded "real" fields. Would like to expose these as the main fields, but firebase matches property names to them anyway
+   *
+   * They also have to be functions because if you try to read them as fields, they always return null! ¯\_(ツ)_/¯
+   */
+
+  @Exclude
+  fun realTime(): Instant = time?.let {
+    Instant.ofEpochMilli(
+        TimeUnit.MILLISECONDS.convert(it, TimeUnit.SECONDS))
+  } ?: Instant.now()
+
+  @Exclude
+  fun realType() = type?.let { HNType.valueOf(it.toUpperCase(Locale.US)) }
+
+  companion object {
+
+    fun create(dataSnapshot: DataSnapshot): HackerNewsComment {
+      return dataSnapshot.getValue(HackerNewsComment::class.java)!!
+    }
+  }
+}

--- a/services/hackernews/src/main/kotlin/io/sweers/catchup/service/hackernews/viewmodelbits/ViewModelAssistedFactory.kt
+++ b/services/hackernews/src/main/kotlin/io/sweers/catchup/service/hackernews/viewmodelbits/ViewModelAssistedFactory.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2019. Zac Sweers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.sweers.catchup.service.hackernews.viewmodelbits
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+
+interface ViewModelAssistedFactory<T : ViewModel> {
+    fun create(savedState: SavedStateHandle): T
+}

--- a/services/hackernews/src/main/kotlin/io/sweers/catchup/service/hackernews/viewmodelbits/ViewModelKey.kt
+++ b/services/hackernews/src/main/kotlin/io/sweers/catchup/service/hackernews/viewmodelbits/ViewModelKey.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2019. Zac Sweers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.sweers.catchup.service.hackernews.viewmodelbits
+
+import androidx.lifecycle.ViewModel
+import dagger.MapKey
+import kotlin.annotation.AnnotationRetention.BINARY
+import kotlin.reflect.KClass
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
+@Retention(value = BINARY)
+@MapKey
+annotation class ViewModelKey(val value: KClass<out ViewModel>)

--- a/services/hackernews/src/main/res/layout/hacker_news_story.xml
+++ b/services/hackernews/src/main/res/layout/hacker_news_story.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2019 Zac Sweers
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app ="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:background="?android:windowBackground"
+    >
+
+  <com.google.android.material.appbar.AppBarLayout
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      >
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        />
+  </com.google.android.material.appbar.AppBarLayout>
+  <ProgressBar
+      android:id="@+id/progress"
+      style="@style/Widget.AppCompat.ProgressBar"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_gravity="center"
+      android:indeterminate="true"
+      />
+  <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+      android:id="@+id/refresh"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior"
+      >
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@android:color/transparent"
+        android:clipToPadding="false"
+        android:fadeScrollbars="true"
+        android:overScrollMode="never"
+        android:scrollbars="vertical"
+        />
+  </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
This replaces the current smmry support with a full blown detail page API around fragments

Still WIP, with hacker news being the main test bed right now

Some obvious things to iron out:
- ~Need to use a custom fragment factory injection so that rotation works (otherwise it tries to reflectively instantiate)~ Done but IRV doesn't save state properly so it's collapsed after rotation now
- ~Still tuning the inboxrecyclerview animation to get it to actually look like it's expanding an item~ Fixed upstream
- IRV currently only allows binding a recycler to one page, ever. Opened an issue to support multiple, as the idea here is to spin up a new page each time. https://github.com/saket/InboxRecyclerView/issues/32