### PR TITLE
Update kotpref and DI-ify it all

### DIFF
--- a/app/src/debug/kotlin/io/sweers/catchup/data/DebugPreferences.kt
+++ b/app/src/debug/kotlin/io/sweers/catchup/data/DebugPreferences.kt
@@ -26,8 +26,8 @@ import javax.inject.Singleton
 
 @Singleton
 class DebugPreferences @Inject constructor(
-    application: Application,
-    sharedPreferences: SharedPreferences
+  application: Application,
+  sharedPreferences: SharedPreferences
 ) : KotprefModel(
     contextProvider = object : ContextProvider {
       override fun getApplicationContext(): Context = application

--- a/app/src/debug/kotlin/io/sweers/catchup/data/DebugPreferences.kt
+++ b/app/src/debug/kotlin/io/sweers/catchup/data/DebugPreferences.kt
@@ -15,9 +15,29 @@
  */
 package io.sweers.catchup.data
 
+import android.app.Application
+import android.content.Context
+import android.content.SharedPreferences
+import com.chibatching.kotpref.ContextProvider
 import com.chibatching.kotpref.KotprefModel
+import com.chibatching.kotpref.PreferencesOpener
+import javax.inject.Inject
+import javax.inject.Singleton
 
-object DebugPreferences : KotprefModel() {
+@Singleton
+class DebugPreferences @Inject constructor(
+    application: Application,
+    sharedPreferences: SharedPreferences
+) : KotprefModel(
+    contextProvider = object : ContextProvider {
+      override fun getApplicationContext(): Context = application
+    },
+    opener = object : PreferencesOpener {
+      override fun openPreferences(context: Context, name: String, mode: Int): SharedPreferences {
+        return sharedPreferences
+      }
+    }
+) {
   var animationSpeed by intPref(default = 1, key = "debug_animation_speed")
   var mockModeEnabled by booleanPref(default = false, key = "debug_mock_mode_enabled")
   var networkDelay by longPref(default = 2000L, key = "debug_network_delay")

--- a/app/src/debug/kotlin/io/sweers/catchup/data/MockDataInterceptor.kt
+++ b/app/src/debug/kotlin/io/sweers/catchup/data/MockDataInterceptor.kt
@@ -33,8 +33,8 @@ import okio.source
  * Note: This is pretty unmaintained right now.
  */
 class MockDataInterceptor(
-    @ApplicationContext private val context: Context,
-    private val debugPreferences: DebugPreferences
+  @ApplicationContext private val context: Context,
+  private val debugPreferences: DebugPreferences
 ) : Interceptor {
 
   override fun intercept(chain: Interceptor.Chain): Response {

--- a/app/src/debug/kotlin/io/sweers/catchup/data/MockDataInterceptor.kt
+++ b/app/src/debug/kotlin/io/sweers/catchup/data/MockDataInterceptor.kt
@@ -32,7 +32,10 @@ import okio.source
  *
  * Note: This is pretty unmaintained right now.
  */
-class MockDataInterceptor(@ApplicationContext private val context: Context) : Interceptor {
+class MockDataInterceptor(
+    @ApplicationContext private val context: Context,
+    private val debugPreferences: DebugPreferences
+) : Interceptor {
 
   override fun intercept(chain: Interceptor.Chain): Response {
     val request = chain.request()
@@ -40,7 +43,7 @@ class MockDataInterceptor(@ApplicationContext private val context: Context) : In
     val host = url.host
     val path = url.encodedPath
     val serviceData = SUPPORTED_ENDPOINTS[host]
-    return if (DebugPreferences.mockModeEnabled && serviceData != null && serviceData.supports(path)) {
+    return if (debugPreferences.mockModeEnabled && serviceData != null && serviceData.supports(path)) {
       Response.Builder().request(request)
           .body(context.assets
               .open(formatUrl(serviceData, url)).source().buffer()

--- a/app/src/debug/kotlin/io/sweers/catchup/data/VariantDataModule.kt
+++ b/app/src/debug/kotlin/io/sweers/catchup/data/VariantDataModule.kt
@@ -70,8 +70,8 @@ object VariantDataModule {
   @JvmStatic
   @Singleton
   internal fun provideMockDataInterceptor(
-      @ApplicationContext context: Context,
-      debugPreferences: DebugPreferences
+    @ApplicationContext context: Context,
+    debugPreferences: DebugPreferences
   ): Interceptor =
       MockDataInterceptor(context, debugPreferences)
 }

--- a/app/src/debug/kotlin/io/sweers/catchup/data/VariantDataModule.kt
+++ b/app/src/debug/kotlin/io/sweers/catchup/data/VariantDataModule.kt
@@ -69,6 +69,9 @@ object VariantDataModule {
   @IntoSet
   @JvmStatic
   @Singleton
-  internal fun provideMockDataInterceptor(@ApplicationContext context: Context): Interceptor =
-      MockDataInterceptor(context)
+  internal fun provideMockDataInterceptor(
+      @ApplicationContext context: Context,
+      debugPreferences: DebugPreferences
+  ): Interceptor =
+      MockDataInterceptor(context, debugPreferences)
 }

--- a/app/src/debug/kotlin/io/sweers/catchup/ui/DebugViewContainer.kt
+++ b/app/src/debug/kotlin/io/sweers/catchup/ui/DebugViewContainer.kt
@@ -82,12 +82,13 @@ internal class DebugViewContainer @Inject constructor(
   private val lumberYard: LumberYard,
   private val lazyOkHttpClient: Lazy<OkHttpClient>,
   private val syllabus: Syllabus,
-  private val fontHelper: FontHelper
+  private val fontHelper: FontHelper,
+  private val debugPreferences: DebugPreferences
 ) : ViewContainer {
-  private val pixelGridEnabled = DebugPreferences.flowFor { ::pixelGridEnabled }
-  private val pixelRatioEnabled = DebugPreferences.flowFor { ::pixelRatioEnabled }
-  private val scalpelEnabled = DebugPreferences.flowFor { ::scalpelEnabled }
-  private val scalpelWireframeEnabled = DebugPreferences.flowFor { ::scalpelWireframeDrawer }
+  private val pixelGridEnabled = debugPreferences.flowFor { ::pixelGridEnabled }
+  private val pixelRatioEnabled = debugPreferences.flowFor { ::pixelRatioEnabled }
+  private val scalpelEnabled = debugPreferences.flowFor { ::scalpelEnabled }
+  private val scalpelWireframeEnabled = debugPreferences.flowFor { ::scalpelWireframeDrawer }
 
   override fun forActivity(activity: BaseActivity): ViewGroup {
     val contentView = LayoutInflater.from(activity)
@@ -98,7 +99,7 @@ internal class DebugViewContainer @Inject constructor(
     val viewHolder = DebugViewViewHolder(contentView)
 
     val drawerContext = ContextThemeWrapper(activity, R.style.DebugDrawer)
-    val debugView = DebugView(drawerContext, lazyOkHttpClient, lumberYard)
+    val debugView = DebugView(drawerContext, null, lazyOkHttpClient, lumberYard, debugPreferences)
     viewHolder.debugDrawer.addView(debugView)
 
     // Set up the contextual actions to watch views coming in and out of the content area.
@@ -127,7 +128,7 @@ internal class DebugViewContainer @Inject constructor(
         }
 
     // If you have not seen the debug drawer before, show it with a message
-    syllabus.showIfNeverSeen(DebugPreferences::seenDebugDrawer.name, TargetRequest(
+    syllabus.showIfNeverSeen(debugPreferences::seenDebugDrawer.name, TargetRequest(
         target = {
           DrawerTapTarget(
               delegateTarget = TapTarget.forView(debugView.icon,

--- a/app/src/main/kotlin/io/sweers/catchup/CatchUpPreferences.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/CatchUpPreferences.kt
@@ -33,8 +33,8 @@ import kotlin.reflect.KProperty0
 @Keep
 @Singleton
 class CatchUpPreferences @Inject constructor(
-    application: Application,
-    sharedPreferences: SharedPreferences
+  application: Application,
+  sharedPreferences: SharedPreferences
 ) : KotprefModel(
     contextProvider = object : ContextProvider {
       override fun getApplicationContext(): Context = application

--- a/app/src/main/kotlin/io/sweers/catchup/CatchUpPreferences.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/CatchUpPreferences.kt
@@ -15,17 +15,43 @@
  */
 package io.sweers.catchup
 
+import android.app.Application
+import android.content.Context
 import android.content.SharedPreferences
 import androidx.annotation.Keep
+import com.chibatching.kotpref.ContextProvider
 import com.chibatching.kotpref.KotprefModel
+import com.chibatching.kotpref.PreferencesOpener
 import io.sweers.catchup.flowbinding.safeOffer
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import javax.inject.Inject
+import javax.inject.Singleton
 import kotlin.reflect.KProperty0
 
 @Keep
-object CatchUpPreferences : KotprefModel() {
+@Singleton
+class CatchUpPreferences @Inject constructor(
+    application: Application,
+    sharedPreferences: SharedPreferences
+) : KotprefModel(
+    contextProvider = object : ContextProvider {
+      override fun getApplicationContext(): Context = application
+    },
+    opener = object : PreferencesOpener {
+      override fun openPreferences(context: Context, name: String, mode: Int): SharedPreferences {
+        return sharedPreferences
+      }
+    }
+) {
+
+  companion object {
+    const val ITEM_KEY_ABOUT = "about"
+    const val ITEM_KEY_CLEAR_CACHE = "clear_cache"
+    const val SECTION_KEY_ORDER_SERVICES = "reorder_services_section"
+    const val SECTION_KEY_SERVICES = "services"
+  }
 
   var daynightAuto by booleanPref(default = true)
   var dayNight by booleanPref(default = false)
@@ -34,11 +60,6 @@ object CatchUpPreferences : KotprefModel() {
   var servicesOrderSeen by booleanPref(default = false)
   var smartlinkingGlobal by booleanPref(default = true)
   var themeNavigationBar by booleanPref(default = false)
-
-  const val about = "about"
-  const val clearCache = "clear_cache"
-  const val reorderServicesSection = "reorder_services_section"
-  var services = "services"
   var servicesOrder by nullableStringPref(default = null)
 }
 

--- a/app/src/main/kotlin/io/sweers/catchup/app/ApplicationModule.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/app/ApplicationModule.kt
@@ -17,7 +17,6 @@ package io.sweers.catchup.app
 
 import android.app.Application
 import android.content.Context
-import com.chibatching.kotpref.Kotpref
 import com.gabrielittner.threetenbp.LazyThreeTen
 import dagger.Binds
 import dagger.Module
@@ -114,14 +113,6 @@ abstract class ApplicationModule {
     fun mainDispatcherInit(): () -> Unit = {
       // This makes a call to disk, so initialize it off the main thread first... ironically
       Dispatchers.Main
-    }
-
-    @Initializers
-    @JvmStatic
-    @IntoSet
-    @Provides
-    fun kotprefInit(application: Application): () -> Unit = {
-      Kotpref.init(application)
     }
   }
 }

--- a/app/src/main/kotlin/io/sweers/catchup/app/CatchUpApplication.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/app/CatchUpApplication.kt
@@ -16,7 +16,6 @@
 package io.sweers.catchup.app
 
 import android.app.Application
-import android.content.SharedPreferences
 import android.os.Looper
 import androidx.appcompat.app.AppCompatDelegate
 import com.f2prateek.rx.preferences2.RxSharedPreferences
@@ -59,7 +58,7 @@ class CatchUpApplication : Application(), HasAndroidInjector {
   @Inject
   internal lateinit var androidInjector: DispatchingAndroidInjector<Any>
   @Inject
-  internal lateinit var sharedPreferences: SharedPreferences
+  internal lateinit var catchUpPreferences: CatchUpPreferences
   @Inject
   internal lateinit var rxPreferences: RxSharedPreferences
 
@@ -85,7 +84,7 @@ class CatchUpApplication : Application(), HasAndroidInjector {
     super.onCreate()
     appComponent = inject()
 
-    CatchUpPreferences.flowFor { ::daynightAuto }
+    catchUpPreferences.flowFor { ::daynightAuto }
         .onEach { autoEnabled ->
             d { "Updating daynight" }
             // Someday would like to add activity lifecycle callbacks to automatically call recreate
@@ -93,7 +92,7 @@ class CatchUpApplication : Application(), HasAndroidInjector {
             var nightMode = AppCompatDelegate.MODE_NIGHT_NO
             if (autoEnabled) {
               nightMode = AppCompatDelegate.MODE_NIGHT_AUTO_BATTERY
-            } else if (CatchUpPreferences.dayNight) {
+            } else if (catchUpPreferences.dayNight) {
               nightMode = AppCompatDelegate.MODE_NIGHT_YES
             }
             AppCompatDelegate.setDefaultNightMode(nightMode)

--- a/app/src/main/kotlin/io/sweers/catchup/data/LinkManager.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/data/LinkManager.kt
@@ -54,7 +54,8 @@ import javax.inject.Inject
 @PerActivity
 class LinkManager @Inject constructor(
   private val customTab: CustomTabActivityHelper,
-  private val activity: Activity
+  private val activity: Activity,
+  private val catchUpPreferences: CatchUpPreferences
 ) : LinkHandler {
 
   // Naive cache that tracks if we've already resolved for activities that can handle a given host
@@ -71,7 +72,7 @@ class LinkManager @Inject constructor(
     filter.addAction(Intent.ACTION_PACKAGE_CHANGED)
     activity.lifecycleScope.launch {
       activity.intentReceivers(filter)
-          .mergeWith(CatchUpPreferences.flowFor { ::smartlinkingGlobal })
+          .mergeWith(catchUpPreferences.flowFor { ::smartlinkingGlobal })
           .collect { dumbCache.clear() }
     }
   }
@@ -116,7 +117,7 @@ class LinkManager @Inject constructor(
       return
     }
     val intent = Intent(Intent.ACTION_VIEW, meta.uri)
-    if (!CatchUpPreferences.smartlinkingGlobal) {
+    if (!catchUpPreferences.smartlinkingGlobal) {
       openCustomTab(meta.context, uri, meta.accentColor)
       return
     }

--- a/app/src/main/kotlin/io/sweers/catchup/ui/activity/OrderServicesActivity.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/ui/activity/OrderServicesActivity.kt
@@ -17,7 +17,6 @@ package io.sweers.catchup.ui.activity
 
 import android.animation.AnimatorInflater
 import android.content.Context
-import android.content.SharedPreferences
 import android.graphics.Rect
 import android.os.Bundle
 import android.os.Parcelable

--- a/app/src/main/kotlin/io/sweers/catchup/ui/activity/OrderServicesActivity.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/ui/activity/OrderServicesActivity.kt
@@ -93,7 +93,7 @@ class OrderServicesFragment : InjectableBaseFragment() {
   @Inject
   lateinit var serviceMetas: Map<String, @JvmSuppressWildcards ServiceMeta>
   @Inject
-  lateinit var sharedPrefs: SharedPreferences
+  lateinit var catchUpPreferences: CatchUpPreferences
   @Inject
   internal lateinit var syllabus: Syllabus
   @Inject
@@ -140,7 +140,7 @@ class OrderServicesFragment : InjectableBaseFragment() {
     }
     val lm = LinearLayoutManager(view.context)
     recyclerView.layoutManager = lm
-    storedOrder = CatchUpPreferences.servicesOrder?.split(",") ?: emptyList()
+    storedOrder = catchUpPreferences.servicesOrder?.split(",") ?: emptyList()
     val instanceChanges = savedInstanceState?.getStringArrayList("pendingChanges")
     pendingChanges = instanceChanges?.map { serviceMetas[it] as ServiceMeta }
     val displayOrder = instanceChanges ?: storedOrder
@@ -176,7 +176,7 @@ class OrderServicesFragment : InjectableBaseFragment() {
 
     save.setOnClickListener {
       pendingChanges?.let { changes ->
-        CatchUpPreferences.bulk {
+        catchUpPreferences.bulk {
           servicesOrder = changes.joinToString(",", transform = ServiceMeta::id)
         }
       }
@@ -185,7 +185,7 @@ class OrderServicesFragment : InjectableBaseFragment() {
 
     val primaryColor = ContextCompat.getColor(save.context, R.color.colorPrimary)
     val textColor = save.context.resolveAttributeColor(android.R.attr.textColorPrimary)
-    syllabus.showIfNeverSeen(CatchUpPreferences::servicesOrderSeen.name,
+    syllabus.showIfNeverSeen(catchUpPreferences::servicesOrderSeen.name,
         TargetRequest(
             target = {
               FabShowTapTarget(delegateTarget = { TapTarget.forView(save, "", "") },

--- a/app/src/main/kotlin/io/sweers/catchup/ui/activity/ServiceSettingsActivity.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/ui/activity/ServiceSettingsActivity.kt
@@ -17,7 +17,6 @@ package io.sweers.catchup.ui.activity
 
 import android.content.Context
 import android.content.Intent
-import android.content.SharedPreferences
 import android.os.Bundle
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.appcompat.widget.Toolbar

--- a/app/src/main/kotlin/io/sweers/catchup/ui/activity/ServiceSettingsActivity.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/ui/activity/ServiceSettingsActivity.kt
@@ -85,7 +85,7 @@ class ServiceSettingsActivity : InjectingBaseActivity() {
     lateinit var serviceMetas: Map<String, @JvmSuppressWildcards ServiceMeta>
 
     @Inject
-    lateinit var sharedPrefs: SharedPreferences
+    lateinit var catchUpPreferences: CatchUpPreferences
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
       AndroidSupportInjection.inject(this)
@@ -106,7 +106,7 @@ class ServiceSettingsActivity : InjectingBaseActivity() {
     private fun setUpGeneralSettings() {
       preferenceScreen = preferenceManager.createPreferenceScreen(activity)
 
-      val currentOrder = CatchUpPreferences.servicesOrder?.split(",")
+      val currentOrder = catchUpPreferences.servicesOrder?.split(",")
           ?: emptyList()
       serviceMetas
           .values

--- a/app/src/main/kotlin/io/sweers/catchup/ui/activity/SettingsActivity.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/ui/activity/SettingsActivity.kt
@@ -126,6 +126,8 @@ class SettingsActivity : InjectingBaseActivity() {
     lateinit var lumberYard: LumberYard
     @Inject
     lateinit var sharedPreferences: SharedPreferences
+    @Inject
+    lateinit var catchUpPreferences: CatchUpPreferences
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
       AndroidSupportInjection.inject(this)
@@ -137,65 +139,65 @@ class SettingsActivity : InjectingBaseActivity() {
         it.isIconSpaceReserved = false
       }
 
-      (findPreference(CatchUpPreferences::smartlinkingGlobal.name) as? CheckBoxPreference)?.isChecked = CatchUpPreferences.smartlinkingGlobal
-      (findPreference(CatchUpPreferences::daynightAuto.name) as? CheckBoxPreference)?.isChecked = CatchUpPreferences.daynightAuto
-      (findPreference(CatchUpPreferences::dayNightForceNight.name) as? CheckBoxPreference)?.isChecked = CatchUpPreferences.dayNightForceNight
-      (findPreference(CatchUpPreferences::reports.name) as? CheckBoxPreference)?.isChecked = CatchUpPreferences.reports
+      (findPreference(catchUpPreferences::smartlinkingGlobal.name) as? CheckBoxPreference)?.isChecked = catchUpPreferences.smartlinkingGlobal
+      (findPreference(catchUpPreferences::daynightAuto.name) as? CheckBoxPreference)?.isChecked = catchUpPreferences.daynightAuto
+      (findPreference(catchUpPreferences::dayNightForceNight.name) as? CheckBoxPreference)?.isChecked = catchUpPreferences.dayNightForceNight
+      (findPreference(catchUpPreferences::reports.name) as? CheckBoxPreference)?.isChecked = catchUpPreferences.reports
 
-      val themeNavBarPref = findPreference(CatchUpPreferences::themeNavigationBar.name) as? CheckBoxPreference
-      themeNavBarPref?.isChecked = CatchUpPreferences.themeNavigationBar
+      val themeNavBarPref = findPreference(catchUpPreferences::themeNavigationBar.name) as? CheckBoxPreference
+      themeNavBarPref?.isChecked = catchUpPreferences.themeNavigationBar
     }
 
     override fun onPreferenceTreeClick(preference: Preference): Boolean {
       when (preference.key) {
-        CatchUpPreferences::smartlinkingGlobal.name -> {
-          CatchUpPreferences.smartlinkingGlobal = (preference as CheckBoxPreference).isChecked
+        catchUpPreferences::smartlinkingGlobal.name -> {
+          catchUpPreferences.smartlinkingGlobal = (preference as CheckBoxPreference).isChecked
           return true
         }
-        CatchUpPreferences::daynightAuto.name -> {
+        catchUpPreferences::daynightAuto.name -> {
           val isChecked = (preference as CheckBoxPreference).isChecked
-          CatchUpPreferences.daynightAuto = isChecked
+          catchUpPreferences.daynightAuto = isChecked
               .apply {
                 if (isChecked) {
                   // If we're enabling auto, clear out the prev daynight night-only mode
-                  CatchUpPreferences.dayNightForceNight = false
-                  (findPreference(CatchUpPreferences::dayNightForceNight.name) as? CheckBoxPreference)?.isChecked = false
+                  catchUpPreferences.dayNightForceNight = false
+                  (findPreference(catchUpPreferences::dayNightForceNight.name) as? CheckBoxPreference)?.isChecked = false
                 }
               }
-          activity?.updateNightMode()
+          activity?.updateNightMode(catchUpPreferences)
           return true
         }
-        CatchUpPreferences::dayNightForceNight.name -> {
-          CatchUpPreferences.dayNightForceNight = (preference as CheckBoxPreference).isChecked
-          activity?.updateNightMode()
+        catchUpPreferences::dayNightForceNight.name -> {
+          catchUpPreferences.dayNightForceNight = (preference as CheckBoxPreference).isChecked
+          activity?.updateNightMode(catchUpPreferences)
           return true
         }
-        CatchUpPreferences::themeNavigationBar.name -> {
-          CatchUpPreferences.themeNavigationBar = (preference as CheckBoxPreference).isChecked
+        catchUpPreferences::themeNavigationBar.name -> {
+          catchUpPreferences.themeNavigationBar = (preference as CheckBoxPreference).isChecked
           (activity as SettingsActivity).run {
             resultData.putBoolean(NAV_COLOR_UPDATED, true)
-            updateNavBarColor(recreate = true)
+            updateNavBarColor(recreate = true, catchUpPreferences = catchUpPreferences)
           }
           return true
         }
-        CatchUpPreferences::reorderServicesSection.name -> {
+        CatchUpPreferences.SECTION_KEY_ORDER_SERVICES -> {
           (activity as SettingsActivity).resultData.putBoolean(SERVICE_ORDER_UPDATED, true)
           startActivity(Intent(activity, OrderServicesActivity::class.java))
           return true
         }
-        CatchUpPreferences::reports.name -> {
+        catchUpPreferences::reports.name -> {
           val isChecked = (preference as CheckBoxPreference).isChecked
-          CatchUpPreferences.reports = isChecked
+          catchUpPreferences.reports = isChecked
           Snackbar.make(view!!, R.string.settings_reset, Snackbar.LENGTH_SHORT)
               .setAction(R.string.undo) {
                 // TODO Maybe this should actually be a restart button
-                CatchUpPreferences.reports = !isChecked
+                catchUpPreferences.reports = !isChecked
                 preference.isChecked = !isChecked
               }
               .show()
           return true
         }
-        CatchUpPreferences::clearCache.name -> {
+        CatchUpPreferences.ITEM_KEY_CLEAR_CACHE -> {
           Single.fromCallable {
             // TODO would be nice to measure the size impact of this file ¯\_(ツ)_/¯
             sharedPreferences.edit().clear().apply()
@@ -229,11 +231,11 @@ class SettingsActivity : InjectingBaseActivity() {
               }
           return true
         }
-        CatchUpPreferences::about.name -> {
+        CatchUpPreferences.ITEM_KEY_ABOUT -> {
           startActivity(Intent(activity, AboutActivity::class.java))
           return true
         }
-        CatchUpPreferences::services.name -> {
+        CatchUpPreferences.SECTION_KEY_SERVICES -> {
           (activity as SettingsActivity).resultData.putBoolean(SERVICE_ORDER_UPDATED, true)
           startActivity(Intent(activity, ServiceSettingsActivity::class.java))
           return true

--- a/app/src/main/kotlin/io/sweers/catchup/ui/base/BaseActivity.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/ui/base/BaseActivity.kt
@@ -27,6 +27,7 @@ import com.uber.autodispose.lifecycle.CorrespondingEventsFunction
 import com.uber.autodispose.lifecycle.LifecycleScopeProvider
 import dagger.android.AndroidInjection
 import io.reactivex.Observable
+import io.sweers.catchup.CatchUpPreferences
 import io.sweers.catchup.ui.ViewContainer
 import io.sweers.catchup.ui.base.ActivityEvent.CREATE
 import io.sweers.catchup.ui.base.ActivityEvent.DESTROY
@@ -114,6 +115,8 @@ abstract class BaseActivity : AppCompatActivity(), LifecycleScopeProvider<Activi
 
   @Inject
   protected lateinit var viewContainer: ViewContainer
+  @Inject
+  protected lateinit var catchUpPreferences: CatchUpPreferences
 
   @CheckResult
   override fun lifecycle(): Observable<ActivityEvent> {
@@ -156,7 +159,7 @@ abstract class BaseActivity : AppCompatActivity(), LifecycleScopeProvider<Activi
 
   override fun onAttachedToWindow() {
     super.onAttachedToWindow()
-    updateNavBarColor()
+    updateNavBarColor(catchUpPreferences = catchUpPreferences)
   }
 
   @CallSuper

--- a/app/src/main/kotlin/io/sweers/catchup/ui/fragments/PagerFragment.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/ui/fragments/PagerFragment.kt
@@ -94,6 +94,8 @@ class PagerFragment : InjectingBaseFragment() {
   lateinit var serviceHandlers: Array<ServiceHandler>
   @Inject
   lateinit var changelogHelper: ChangelogHelper
+  @Inject
+  lateinit var catchUpPreferences: CatchUpPreferences
 
   private val rootLayout by bindView<CoordinatorLayout>(R.id.pager_fragment_root)
   private val tabLayout by bindView<TabLayout>(R.id.tab_layout)
@@ -251,7 +253,8 @@ class PagerFragment : InjectingBaseFragment() {
             activity?.window?.statusBarColor = color
           }
           activity?.updateNavBarColor(color,
-              context = view.context)
+              context = view.context,
+              catchUpPreferences = catchUpPreferences)
         }
       }
 
@@ -298,7 +301,8 @@ class PagerFragment : InjectingBaseFragment() {
                     activity?.window?.statusBarColor = color
                   }
                   activity?.updateNavBarColor(color,
-                      context = view.context)
+                      context = view.context,
+                      catchUpPreferences = catchUpPreferences)
                 }
                 start()
               }
@@ -350,7 +354,8 @@ class PagerFragment : InjectingBaseFragment() {
           if (extras.getBoolean(SettingsActivity.NAV_COLOR_UPDATED, false)) {
             activity?.updateNavBarColor(color = (tabLayout.background as ColorDrawable).color,
                 context = view!!.context,
-                recreate = true)
+                recreate = true,
+                catchUpPreferences = catchUpPreferences)
           }
         }
       }
@@ -364,9 +369,10 @@ class PagerFragment : InjectingBaseFragment() {
     @Provides
     fun provideServiceHandlers(
       sharedPrefs: SharedPreferences,
-      serviceMetas: Map<String, @JvmSuppressWildcards ServiceMeta>
+      serviceMetas: Map<String, @JvmSuppressWildcards ServiceMeta>,
+      catchUpPreferences: CatchUpPreferences
     ): Array<ServiceHandler> {
-      val currentOrder = CatchUpPreferences.servicesOrder?.split(",") ?: emptyList()
+      val currentOrder = catchUpPreferences.servicesOrder?.split(",") ?: emptyList()
       return (serviceMetas.values
           .filter(ServiceMeta::enabled)
           .filter { sharedPrefs.getBoolean(it.enabledPreferenceKey, true) }

--- a/app/src/main/kotlin/io/sweers/catchup/util/ActivityExt.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/util/ActivityExt.kt
@@ -24,11 +24,11 @@ import androidx.activity.ComponentActivity
 import androidx.appcompat.app.AppCompatDelegate
 import io.sweers.catchup.CatchUpPreferences
 
-inline fun Activity.updateNightMode() {
+inline fun Activity.updateNightMode(catchUpPreferences: CatchUpPreferences) {
   val isCurrentlyInNightMode = isInNightMode()
   val nightMode = when {
-    CatchUpPreferences.daynightAuto -> AppCompatDelegate.MODE_NIGHT_AUTO_BATTERY
-    CatchUpPreferences.dayNightForceNight -> AppCompatDelegate.MODE_NIGHT_YES
+    catchUpPreferences.daynightAuto -> AppCompatDelegate.MODE_NIGHT_AUTO_BATTERY
+    catchUpPreferences.dayNightForceNight -> AppCompatDelegate.MODE_NIGHT_YES
     else -> AppCompatDelegate.MODE_NIGHT_NO
   }
   if (nightMode == AppCompatDelegate.MODE_NIGHT_AUTO_BATTERY ||

--- a/app/src/main/kotlin/io/sweers/catchup/util/AppLocalExtensions.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/util/AppLocalExtensions.kt
@@ -27,11 +27,12 @@ import io.sweers.catchup.R
 fun Activity.updateNavBarColor(
   @ColorInt color: Int? = null,
   context: Context = this,
-  recreate: Boolean = false
+  recreate: Boolean = false,
+  catchUpPreferences: CatchUpPreferences
 ) {
   // Update the nav bar with whatever prefs we had
   @Suppress("CascadeIf") // Because I think if-else makes more sense readability-wise
-  if (color != null && CatchUpPreferences.themeNavigationBar) {
+  if (color != null && catchUpPreferences.themeNavigationBar) {
     window.navigationBarColor = color
     window.navigationBarDividerColor = Color.TRANSPARENT
     window.decorView.clearLightNavBar() // TODO why do I need to do this every time?

--- a/buildSrc/src/main/kotlin/dependencies.kt
+++ b/buildSrc/src/main/kotlin/dependencies.kt
@@ -68,7 +68,7 @@ object deps {
     const val hyperion = "0.9.24"
     const val inspector = "0.3.0"
     const val kotlin = "1.3.50-eap-54"
-    const val kotpref = "2.8.0"
+    const val kotpref = "2.9.1"
     const val leakcanary = "2.0-beta-2"
     const val legacySupport = "28.0.0"
     const val markwon = "4.1.0"


### PR DESCRIPTION
The new version of Kotpref allows for defining a custom SharedPreferences instance. This allows for shared reuse of the same shared prefs instance everywhere (which should preserve some existing prefs for updating users as well as better support the clear cache section).