### PR TITLE
WIP try to use desugar for java.time

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,7 +49,6 @@ android {
     targetSdkVersion(deps.android.build.targetSdkVersion)
     versionCode = deps.build.versionCodePH
     versionName = deps.build.versionNamePH
-    multiDexEnabled = false
 
     the<BasePluginConvention>().archivesBaseName = "catchup"
     vectorDrawables.useSupportLibrary = true
@@ -86,6 +85,7 @@ android {
     }
   }
   compileOptions {
+    setCoreLibraryDesugaringEnabled(true)
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
   }
@@ -238,7 +238,7 @@ apollo {
   service("github") {
     @Suppress("UnstableApiUsage")
     customTypeMapping.set(mapOf(
-        "DateTime" to "org.threeten.bp.Instant",
+        "DateTime" to "java.time.Instant",
         "URI" to "okhttp3.HttpUrl"
     ))
     generateKotlinModels.set(true)
@@ -480,7 +480,6 @@ dependencies {
   implementation(deps.retrofit.rxJava2)
   implementation(deps.rx.android)
   implementation(deps.rx.java)
-  implementation(deps.misc.lazythreeten)
   implementation(deps.misc.tapTargetView)
   implementation(deps.misc.timber)
   implementation(deps.misc.debug.processPhoenix)

--- a/app/src/main/kotlin/io/sweers/catchup/app/ApplicationModule.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/app/ApplicationModule.kt
@@ -33,7 +33,6 @@ import coil.request.LoadRequest
 import coil.request.RequestDisposable
 import coil.util.CoilLogger
 import coil.util.CoilUtils.createDefaultCache
-import com.gabrielittner.threetenbp.LazyThreeTen
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -145,15 +144,6 @@ abstract class ApplicationModule {
           ))
           .build()
         }
-
-    @AsyncInitializers
-    @JvmStatic
-    @IntoSet
-    @Provides
-    fun threeTenInit(application: Application): () -> Unit = {
-      LazyThreeTen.init(application)
-      LazyThreeTen.cacheZones()
-    }
 
     @AsyncInitializers
     @JvmStatic

--- a/app/src/main/kotlin/io/sweers/catchup/data/CatchUpDatabase.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/data/CatchUpDatabase.kt
@@ -23,7 +23,7 @@ import androidx.room.TypeConverter
 import androidx.room.TypeConverters
 import io.sweers.catchup.service.api.CatchUpItem
 import io.sweers.catchup.service.api.SummarizationType
-import org.threeten.bp.Instant
+import java.time.Instant
 
 @Database(
     entities = [

--- a/app/src/main/kotlin/io/sweers/catchup/data/ISO8601InstantApolloAdapter.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/data/ISO8601InstantApolloAdapter.kt
@@ -19,7 +19,7 @@ import com.apollographql.apollo.response.CustomTypeAdapter
 import com.apollographql.apollo.response.CustomTypeValue
 import com.apollographql.apollo.response.CustomTypeValue.GraphQLString
 import io.sweers.catchup.util.parsePossiblyOffsetInstant
-import org.threeten.bp.Instant
+import java.time.Instant
 
 /**
  * A CustomTypeAdapter for apollo that can convert ISO style date strings to Instant.

--- a/app/src/main/kotlin/io/sweers/catchup/data/LumberYard.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/data/LumberYard.kt
@@ -27,8 +27,8 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import okio.BufferedSink
 import okio.buffer
 import okio.sink
-import org.threeten.bp.LocalDateTime
-import org.threeten.bp.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME
 import timber.log.Timber
 import java.io.File
 import java.io.IOException

--- a/app/src/main/kotlin/io/sweers/catchup/data/ServiceDao.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/data/ServiceDao.kt
@@ -25,7 +25,7 @@ import androidx.room.Query
 import io.reactivex.Completable
 import io.reactivex.Maybe
 import io.sweers.catchup.service.api.CatchUpItem
-import org.threeten.bp.Instant
+import java.time.Instant
 
 @Dao
 interface ServiceDao {

--- a/app/src/main/kotlin/io/sweers/catchup/ui/about/ChangelogFragment.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/ui/about/ChangelogFragment.kt
@@ -47,7 +47,8 @@ import io.sweers.catchup.util.hide
 import io.sweers.catchup.util.w
 import jp.wasabeef.recyclerview.animators.FadeInUpAnimator
 import kotlinx.coroutines.launch
-import org.threeten.bp.Instant
+import kotterknife.bindView
+import java.time.Instant
 import java.io.IOException
 import javax.inject.Inject
 

--- a/app/src/main/kotlin/io/sweers/catchup/ui/base/CatchUpItemViewHolder.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/ui/base/CatchUpItemViewHolder.kt
@@ -42,7 +42,8 @@ import io.sweers.catchup.util.kotlin.format
 import io.sweers.catchup.util.primaryLocale
 import io.sweers.catchup.util.show
 import io.sweers.catchup.util.showIf
-import org.threeten.bp.Instant
+import kotterknife.bindView
+import java.time.Instant
 
 class CatchUpItemViewHolder(
   itemView: View

--- a/app/src/main/kotlin/io/sweers/catchup/ui/fragments/service/StorageBackedService.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/ui/fragments/service/StorageBackedService.kt
@@ -33,8 +33,8 @@ import io.sweers.catchup.service.api.UrlMeta
 import io.sweers.catchup.util.kotlin.switchIf
 import io.sweers.catchup.util.w
 import kotlinx.coroutines.channels.SendChannel
-import org.threeten.bp.Instant
-import org.threeten.bp.temporal.ChronoUnit
+import java.time.Instant
+import java.time.temporal.ChronoUnit
 import retrofit2.HttpException
 import java.io.IOException
 

--- a/buildSrc/src/main/kotlin/dependencies.kt
+++ b/buildSrc/src/main/kotlin/dependencies.kt
@@ -375,7 +375,6 @@ object deps {
     const val jsr305 = "com.google.code.findbugs:jsr305:3.0.2"
     const val kotpref = "com.chibatching.kotpref:kotpref:${versions.kotpref}"
     const val kotprefEnum = "com.chibatching.kotpref:enum-support:${versions.kotpref}"
-    const val lazythreeten = "com.gabrielittner.threetenbp:lazythreetenbp:0.8.0"
     const val lottie = "com.airbnb.android:lottie:3.3.1"
     const val moshiLazyAdapters = "com.serjltt.moshi:moshi-lazy-adapters:2.2"
     const val okio = "com.squareup.okio:okio:2.4.3"

--- a/libraries/util/build.gradle.kts
+++ b/libraries/util/build.gradle.kts
@@ -29,6 +29,7 @@ android {
     targetSdkVersion(deps.android.build.targetSdkVersion)
   }
   compileOptions {
+    setCoreLibraryDesugaringEnabled(true)
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
   }
@@ -70,7 +71,6 @@ dependencies {
   api(deps.android.androidx.coreKtx)
   api(deps.dagger.runtime)
   api(deps.kotlin.stdlib.jdk7)
-  api(deps.misc.lazythreeten)
   api(deps.moshi.core)
   api(deps.misc.timber)
   api(deps.okhttp.core)

--- a/libraries/util/src/main/kotlin/io/sweers/catchup/util/InstantExt.kt
+++ b/libraries/util/src/main/kotlin/io/sweers/catchup/util/InstantExt.kt
@@ -17,8 +17,8 @@
 
 package io.sweers.catchup.util
 
-import org.threeten.bp.Instant
-import org.threeten.bp.OffsetDateTime
+import java.time.Instant
+import java.time.OffsetDateTime
 
 /*
  * Utilities for dealing with [Instant]

--- a/libraries/util/src/main/kotlin/io/sweers/catchup/util/data/adapters/EpochInstantJsonAdapter.kt
+++ b/libraries/util/src/main/kotlin/io/sweers/catchup/util/data/adapters/EpochInstantJsonAdapter.kt
@@ -18,7 +18,7 @@ package io.sweers.catchup.util.data.adapters
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonWriter
-import org.threeten.bp.Instant
+import java.time.Instant
 import java.io.IOException
 import java.util.concurrent.TimeUnit
 

--- a/libraries/util/src/main/kotlin/io/sweers/catchup/util/data/adapters/ISO8601InstantAdapter.kt
+++ b/libraries/util/src/main/kotlin/io/sweers/catchup/util/data/adapters/ISO8601InstantAdapter.kt
@@ -19,7 +19,7 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonWriter
 import io.sweers.catchup.util.parsePossiblyOffsetInstant
-import org.threeten.bp.Instant
+import java.time.Instant
 import java.io.IOException
 
 class ISO8601InstantAdapter : JsonAdapter<Instant>() {

--- a/service-api/build.gradle.kts
+++ b/service-api/build.gradle.kts
@@ -34,6 +34,7 @@ android {
     targetSdkVersion(deps.android.build.targetSdkVersion)
   }
   compileOptions {
+    setCoreLibraryDesugaringEnabled(true)
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
   }
@@ -74,7 +75,6 @@ dependencies {
   api(deps.android.androidx.fragment)
   api(deps.dagger.runtime)
   api(deps.kotlin.coroutines)
-  api(deps.misc.lazythreeten)
   api(deps.rx.java)
 
   implementation(deps.okhttp.core)

--- a/service-api/src/main/kotlin/io/sweers/catchup/service/api/CatchUpItem.kt
+++ b/service-api/src/main/kotlin/io/sweers/catchup/service/api/CatchUpItem.kt
@@ -19,7 +19,7 @@ import androidx.annotation.Keep
 import androidx.room.Embedded
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import org.threeten.bp.Instant
+import java.time.Instant
 
 @Keep
 @Entity(tableName = "items")

--- a/services/designernews/build.gradle.kts
+++ b/services/designernews/build.gradle.kts
@@ -35,6 +35,7 @@ android {
     vectorDrawables.useSupportLibrary = true
   }
   compileOptions {
+    setCoreLibraryDesugaringEnabled(true)
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
   }
@@ -82,6 +83,5 @@ dependencies {
   api(project(":service-api"))
   api(deps.android.androidx.annotations)
   api(deps.dagger.runtime)
-  api(deps.misc.lazythreeten)
   api(deps.rx.java)
 }

--- a/services/designernews/src/main/kotlin/io/sweers/catchup/service/designernews/DesignerNewsService.kt
+++ b/services/designernews/src/main/kotlin/io/sweers/catchup/service/designernews/DesignerNewsService.kt
@@ -38,7 +38,7 @@ import io.sweers.catchup.serviceregistry.annotations.Meta
 import io.sweers.catchup.serviceregistry.annotations.ServiceModule
 import io.sweers.catchup.util.data.adapters.ISO8601InstantAdapter
 import okhttp3.OkHttpClient
-import org.threeten.bp.Instant
+import java.time.Instant
 import retrofit2.Retrofit
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import retrofit2.converter.moshi.MoshiConverterFactory

--- a/services/designernews/src/main/kotlin/io/sweers/catchup/service/designernews/model/Comment.kt
+++ b/services/designernews/src/main/kotlin/io/sweers/catchup/service/designernews/model/Comment.kt
@@ -17,7 +17,7 @@ package io.sweers.catchup.service.designernews.model
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
-import org.threeten.bp.Instant
+import java.time.Instant
 
 /**
  * Models a comment on a designer news story.

--- a/services/designernews/src/main/kotlin/io/sweers/catchup/service/designernews/model/Story.kt
+++ b/services/designernews/src/main/kotlin/io/sweers/catchup/service/designernews/model/Story.kt
@@ -17,7 +17,7 @@ package io.sweers.catchup.service.designernews.model
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
-import org.threeten.bp.Instant
+import java.time.Instant
 
 /**
  * Models a Designer News story

--- a/services/dribbble/build.gradle.kts
+++ b/services/dribbble/build.gradle.kts
@@ -35,6 +35,7 @@ android {
     vectorDrawables.useSupportLibrary = true
   }
   compileOptions {
+    setCoreLibraryDesugaringEnabled(true)
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
   }
@@ -76,6 +77,5 @@ dependencies {
   api(project(":service-api"))
   api(deps.android.androidx.annotations)
   api(deps.dagger.runtime)
-  api(deps.misc.lazythreeten)
   api(deps.rx.java)
 }

--- a/services/dribbble/src/main/kotlin/io/sweers/catchup/service/dribbble/DribbbleParser.kt
+++ b/services/dribbble/src/main/kotlin/io/sweers/catchup/service/dribbble/DribbbleParser.kt
@@ -23,8 +23,8 @@ import io.sweers.catchup.service.dribbble.model.User
 import okhttp3.ResponseBody
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Element
-import org.threeten.bp.Instant
-import org.threeten.bp.format.DateTimeFormatter
+import java.time.Instant
+import java.time.format.DateTimeFormatter
 import java.util.regex.Pattern
 
 /**
@@ -62,7 +62,8 @@ internal object DribbbleParser {
     val createdAt: Instant = try {
       DATE_FORMAT.parse(descriptionBlock.select("em.timestamp")
           .first()
-          .text(), Instant.FROM)
+          .text(),
+          Instant::from)
     } catch (e2: Exception) {
       Instant.now()
     }

--- a/services/dribbble/src/main/kotlin/io/sweers/catchup/service/dribbble/model/Shot.kt
+++ b/services/dribbble/src/main/kotlin/io/sweers/catchup/service/dribbble/model/Shot.kt
@@ -15,7 +15,7 @@
  */
 package io.sweers.catchup.service.dribbble.model
 
-import org.threeten.bp.Instant
+import java.time.Instant
 
 /**
  * Models a dibbble shot

--- a/services/github/build.gradle.kts
+++ b/services/github/build.gradle.kts
@@ -38,6 +38,7 @@ android {
         "\"${properties["catchup_github_developer_token"]}\"")
   }
   compileOptions {
+    setCoreLibraryDesugaringEnabled(true)
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
   }
@@ -69,7 +70,7 @@ apollo {
   service("github") {
     @Suppress("UnstableApiUsage")
     customTypeMapping.set(mapOf(
-        "DateTime" to "org.threeten.bp.Instant",
+        "DateTime" to "java.time.Instant",
         "URI" to "okhttp3.HttpUrl"
     ))
     generateKotlinModels.set(true)
@@ -100,6 +101,5 @@ dependencies {
   api(project(":service-api"))
   api(deps.android.androidx.annotations)
   api(deps.dagger.runtime)
-  api(deps.misc.lazythreeten)
   api(deps.rx.java)
 }

--- a/services/github/src/main/kotlin/io/sweers/catchup/service/github/model/SearchQuery.kt
+++ b/services/github/src/main/kotlin/io/sweers/catchup/service/github/model/SearchQuery.kt
@@ -15,8 +15,8 @@
  */
 package io.sweers.catchup.service.github.model
 
-import org.threeten.bp.LocalDate
-import org.threeten.bp.format.DateTimeFormatter.ISO_LOCAL_DATE
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter.ISO_LOCAL_DATE
 
 internal data class SearchQuery(val createdSince: LocalDate?, val minStars: Int) {
 

--- a/services/github/src/main/kotlin/io/sweers/catchup/service/github/model/TrendingTimespan.kt
+++ b/services/github/src/main/kotlin/io/sweers/catchup/service/github/model/TrendingTimespan.kt
@@ -15,9 +15,9 @@
  */
 package io.sweers.catchup.service.github.model
 
-import org.threeten.bp.LocalDate
-import org.threeten.bp.temporal.ChronoUnit
-import org.threeten.bp.temporal.TemporalUnit
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+import java.time.temporal.TemporalUnit
 
 // https://github.com/google/error-prone/issues/512
 internal enum class TrendingTimespan constructor(

--- a/services/hackernews/build.gradle.kts
+++ b/services/hackernews/build.gradle.kts
@@ -36,6 +36,7 @@ android {
     vectorDrawables.useSupportLibrary = true
   }
   compileOptions {
+    setCoreLibraryDesugaringEnabled(true)
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
   }
@@ -89,6 +90,5 @@ dependencies {
   api(deps.android.androidx.fragmentKtx)
   api(deps.android.androidx.annotations)
   api(deps.dagger.runtime)
-  api(deps.misc.lazythreeten)
   api(deps.rx.java)
 }

--- a/services/hackernews/src/main/kotlin/io/sweers/catchup/service/hackernews/model/HackerNewsStory.kt
+++ b/services/hackernews/src/main/kotlin/io/sweers/catchup/service/hackernews/model/HackerNewsStory.kt
@@ -19,7 +19,7 @@ import androidx.annotation.Keep
 import com.google.firebase.database.DataSnapshot
 import com.google.firebase.database.Exclude
 import io.sweers.catchup.service.api.HasStableId
-import org.threeten.bp.Instant
+import java.time.Instant
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 import kotlin.annotation.AnnotationRetention.SOURCE

--- a/services/imgur/build.gradle.kts
+++ b/services/imgur/build.gradle.kts
@@ -37,6 +37,7 @@ android {
         "\"${project.properties["catchup_imgur_access_token"].toString()}\"")
   }
   compileOptions {
+    setCoreLibraryDesugaringEnabled(true)
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
   }
@@ -78,6 +79,5 @@ dependencies {
   api(project(":service-api"))
   api(deps.android.androidx.annotations)
   api(deps.dagger.runtime)
-  api(deps.misc.lazythreeten)
   api(deps.rx.java)
 }

--- a/services/imgur/src/main/kotlin/io/sweers/catchup/service/imgur/ImgureService.kt
+++ b/services/imgur/src/main/kotlin/io/sweers/catchup/service/imgur/ImgureService.kt
@@ -38,7 +38,7 @@ import io.sweers.catchup.serviceregistry.annotations.ServiceModule
 import io.sweers.catchup.util.data.adapters.EpochInstantJsonAdapter
 import io.sweers.catchup.util.network.AuthInterceptor
 import okhttp3.OkHttpClient
-import org.threeten.bp.Instant
+import java.time.Instant
 import retrofit2.Retrofit.Builder
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import retrofit2.converter.moshi.MoshiConverterFactory

--- a/services/imgur/src/main/kotlin/io/sweers/catchup/service/imgur/model/Image.kt
+++ b/services/imgur/src/main/kotlin/io/sweers/catchup/service/imgur/model/Image.kt
@@ -21,7 +21,7 @@ import android.content.res.Configuration
 import androidx.core.content.getSystemService
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
-import org.threeten.bp.Instant
+import java.time.Instant
 
 @JsonClass(generateAdapter = true)
 internal data class Image(

--- a/services/medium/build.gradle.kts
+++ b/services/medium/build.gradle.kts
@@ -35,6 +35,7 @@ android {
     vectorDrawables.useSupportLibrary = true
   }
   compileOptions {
+    setCoreLibraryDesugaringEnabled(true)
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
   }
@@ -91,6 +92,5 @@ dependencies {
   api(project(":service-api"))
   api(deps.android.androidx.annotations)
   api(deps.dagger.runtime)
-  api(deps.misc.lazythreeten)
   api(deps.rx.java)
 }

--- a/services/medium/src/main/kotlin/io/sweers/catchup/service/medium/MediumService.kt
+++ b/services/medium/src/main/kotlin/io/sweers/catchup/service/medium/MediumService.kt
@@ -41,7 +41,7 @@ import io.sweers.catchup.serviceregistry.annotations.ServiceModule
 import io.sweers.catchup.util.data.adapters.EpochInstantJsonAdapter
 import io.sweers.inspector.Inspector
 import okhttp3.OkHttpClient
-import org.threeten.bp.Instant
+import java.time.Instant
 import retrofit2.Retrofit
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import retrofit2.converter.moshi.MoshiConverterFactory

--- a/services/medium/src/main/kotlin/io/sweers/catchup/service/medium/model/Post.kt
+++ b/services/medium/src/main/kotlin/io/sweers/catchup/service/medium/model/Post.kt
@@ -16,7 +16,7 @@
 package io.sweers.catchup.service.medium.model
 
 import com.squareup.moshi.JsonClass
-import org.threeten.bp.Instant
+import java.time.Instant
 
 @JsonClass(generateAdapter = true)
 internal data class Post(

--- a/services/newsapi/build.gradle.kts
+++ b/services/newsapi/build.gradle.kts
@@ -37,6 +37,7 @@ android {
         "\"${project.properties["catchup_news_api_api_key"].toString()}\"")
   }
   compileOptions {
+    setCoreLibraryDesugaringEnabled(true)
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
   }
@@ -79,6 +80,5 @@ dependencies {
   api(project(":service-api"))
   api(deps.android.androidx.annotations)
   api(deps.dagger.runtime)
-  api(deps.misc.lazythreeten)
   api(deps.rx.java)
 }

--- a/services/newsapi/src/main/kotlin/io/sweers/catchup/service/newsapi/NewsApiService.kt
+++ b/services/newsapi/src/main/kotlin/io/sweers/catchup/service/newsapi/NewsApiService.kt
@@ -46,10 +46,10 @@ import io.sweers.catchup.util.data.adapters.ISO8601InstantAdapter
 import io.sweers.catchup.util.network.AuthInterceptor
 import io.sweers.catchup.util.rx.filterIsInstance
 import okhttp3.OkHttpClient
-import org.threeten.bp.Instant
-import org.threeten.bp.ZoneId
-import org.threeten.bp.format.DateTimeFormatter
-import org.threeten.bp.temporal.ChronoUnit
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 import retrofit2.HttpException
 import retrofit2.Retrofit
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory

--- a/services/newsapi/src/main/kotlin/io/sweers/catchup/service/newsapi/model/Article.kt
+++ b/services/newsapi/src/main/kotlin/io/sweers/catchup/service/newsapi/model/Article.kt
@@ -16,7 +16,7 @@
 package io.sweers.catchup.service.newsapi.model
 
 import com.squareup.moshi.JsonClass
-import org.threeten.bp.Instant
+import java.time.Instant
 
 @JsonClass(generateAdapter = true)
 internal data class Article(

--- a/services/producthunt/build.gradle.kts
+++ b/services/producthunt/build.gradle.kts
@@ -37,6 +37,7 @@ android {
         "\"${project.properties["catchup_product_hunt_developer_token"]}\"")
   }
   compileOptions {
+    setCoreLibraryDesugaringEnabled(true)
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
   }
@@ -85,6 +86,5 @@ dependencies {
   api(project(":service-api"))
   api(deps.android.androidx.annotations)
   api(deps.dagger.runtime)
-  api(deps.misc.lazythreeten)
   api(deps.rx.java)
 }

--- a/services/producthunt/src/main/kotlin/io/sweers/catchup/service/producthunt/ProductHuntService.kt
+++ b/services/producthunt/src/main/kotlin/io/sweers/catchup/service/producthunt/ProductHuntService.kt
@@ -38,7 +38,7 @@ import io.sweers.catchup.serviceregistry.annotations.ServiceModule
 import io.sweers.catchup.util.data.adapters.ISO8601InstantAdapter
 import io.sweers.catchup.util.network.AuthInterceptor
 import okhttp3.OkHttpClient
-import org.threeten.bp.Instant
+import java.time.Instant
 import retrofit2.Retrofit
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import retrofit2.converter.moshi.MoshiConverterFactory

--- a/services/producthunt/src/main/kotlin/io/sweers/catchup/service/producthunt/model/Post.kt
+++ b/services/producthunt/src/main/kotlin/io/sweers/catchup/service/producthunt/model/Post.kt
@@ -19,7 +19,7 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import io.sweers.catchup.util.e
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
-import org.threeten.bp.Instant
+import java.time.Instant
 
 /**
  * Models a post on Product Hunt.

--- a/services/reddit/build.gradle.kts
+++ b/services/reddit/build.gradle.kts
@@ -35,6 +35,7 @@ android {
     vectorDrawables.useSupportLibrary = true
   }
   compileOptions {
+    setCoreLibraryDesugaringEnabled(true)
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
   }
@@ -81,6 +82,5 @@ dependencies {
   api(project(":service-api"))
   api(deps.android.androidx.annotations)
   api(deps.dagger.runtime)
-  api(deps.misc.lazythreeten)
   api(deps.rx.java)
 }

--- a/services/reddit/src/main/kotlin/io/sweers/catchup/service/reddit/RedditService.kt
+++ b/services/reddit/src/main/kotlin/io/sweers/catchup/service/reddit/RedditService.kt
@@ -41,7 +41,7 @@ import io.sweers.catchup.serviceregistry.annotations.ServiceModule
 import io.sweers.catchup.util.data.adapters.EpochInstantJsonAdapter
 import io.sweers.catchup.util.nullIfBlank
 import okhttp3.OkHttpClient
-import org.threeten.bp.Instant
+import java.time.Instant
 import retrofit2.Retrofit
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import retrofit2.converter.moshi.MoshiConverterFactory

--- a/services/reddit/src/main/kotlin/io/sweers/catchup/service/reddit/model/RedditObject.kt
+++ b/services/reddit/src/main/kotlin/io/sweers/catchup/service/reddit/model/RedditObject.kt
@@ -18,7 +18,7 @@ package io.sweers.catchup.service.reddit.model
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import io.sweers.catchup.service.api.HasStableId
-import org.threeten.bp.Instant
+import java.time.Instant
 
 internal sealed class RedditObject
 

--- a/services/slashdot/build.gradle.kts
+++ b/services/slashdot/build.gradle.kts
@@ -35,6 +35,7 @@ android {
     vectorDrawables.useSupportLibrary = true
   }
   compileOptions {
+    setCoreLibraryDesugaringEnabled(true)
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
   }
@@ -78,7 +79,6 @@ dependencies {
   api(project(":service-api"))
   api(deps.android.androidx.annotations)
   api(deps.dagger.runtime)
-  api(deps.misc.lazythreeten)
   api(deps.rx.java)
   api(deps.tikxml.htmlEscape)
 }

--- a/services/slashdot/src/main/kotlin/io/sweers/catchup/service/slashdot/Entry.kt
+++ b/services/slashdot/src/main/kotlin/io/sweers/catchup/service/slashdot/Entry.kt
@@ -23,7 +23,7 @@ import com.tickaroo.tikxml.annotation.Xml
 import com.tickaroo.tikxml.converter.htmlescape.HtmlEscapeStringConverter
 import io.sweers.catchup.service.api.HasStableId
 import io.sweers.catchup.util.parsePossiblyOffsetInstant
-import org.threeten.bp.Instant
+import java.time.Instant
 
 private const val SLASH_PREFIX = "slash:"
 

--- a/services/slashdot/src/main/kotlin/io/sweers/catchup/service/slashdot/SlashdotService.kt
+++ b/services/slashdot/src/main/kotlin/io/sweers/catchup/service/slashdot/SlashdotService.kt
@@ -39,7 +39,7 @@ import io.sweers.catchup.service.api.TextService
 import io.sweers.catchup.serviceregistry.annotations.Meta
 import io.sweers.catchup.serviceregistry.annotations.ServiceModule
 import okhttp3.OkHttpClient
-import org.threeten.bp.Instant
+import java.time.Instant
 import retrofit2.Retrofit
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import javax.inject.Inject

--- a/services/unsplash/build.gradle.kts
+++ b/services/unsplash/build.gradle.kts
@@ -37,6 +37,7 @@ android {
         "\"${project.properties["catchup_unsplash_api_key"]}\"")
   }
   compileOptions {
+    setCoreLibraryDesugaringEnabled(true)
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
   }
@@ -79,6 +80,5 @@ dependencies {
   api(project(":service-api"))
   api(deps.android.androidx.annotations)
   api(deps.dagger.runtime)
-  api(deps.misc.lazythreeten)
   api(deps.rx.java)
 }

--- a/services/unsplash/src/main/kotlin/io/sweers/catchup/service/unsplash/UnsplashService.kt
+++ b/services/unsplash/src/main/kotlin/io/sweers/catchup/service/unsplash/UnsplashService.kt
@@ -39,7 +39,7 @@ import io.sweers.catchup.serviceregistry.annotations.ServiceModule
 import io.sweers.catchup.util.data.adapters.ISO8601InstantAdapter
 import io.sweers.catchup.util.network.AuthInterceptor
 import okhttp3.OkHttpClient
-import org.threeten.bp.Instant
+import java.time.Instant
 import retrofit2.Retrofit
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import retrofit2.converter.moshi.MoshiConverterFactory

--- a/services/unsplash/src/main/kotlin/io/sweers/catchup/service/unsplash/model/UnsplashModels.kt
+++ b/services/unsplash/src/main/kotlin/io/sweers/catchup/service/unsplash/model/UnsplashModels.kt
@@ -17,7 +17,7 @@ package io.sweers.catchup.service.unsplash.model
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
-import org.threeten.bp.Instant
+import java.time.Instant
 
 @JsonClass(generateAdapter = true)
 internal data class UnsplashPhoto(

--- a/services/uplabs/build.gradle.kts
+++ b/services/uplabs/build.gradle.kts
@@ -35,6 +35,7 @@ android {
     vectorDrawables.useSupportLibrary = true
   }
   compileOptions {
+    setCoreLibraryDesugaringEnabled(true)
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
   }
@@ -76,6 +77,5 @@ dependencies {
   api(project(":service-api"))
   api(deps.android.androidx.annotations)
   api(deps.dagger.runtime)
-  api(deps.misc.lazythreeten)
   api(deps.rx.java)
 }

--- a/services/uplabs/src/main/kotlin/io/sweers/catchup/service/uplabs/UplabsService.kt
+++ b/services/uplabs/src/main/kotlin/io/sweers/catchup/service/uplabs/UplabsService.kt
@@ -37,7 +37,7 @@ import io.sweers.catchup.serviceregistry.annotations.Meta
 import io.sweers.catchup.serviceregistry.annotations.ServiceModule
 import io.sweers.catchup.util.data.adapters.ISO8601InstantAdapter
 import okhttp3.OkHttpClient
-import org.threeten.bp.Instant
+import java.time.Instant
 import retrofit2.Retrofit
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import retrofit2.converter.moshi.MoshiConverterFactory

--- a/services/uplabs/src/main/kotlin/io/sweers/catchup/service/uplabs/model/UplabsModels.kt
+++ b/services/uplabs/src/main/kotlin/io/sweers/catchup/service/uplabs/model/UplabsModels.kt
@@ -17,7 +17,7 @@ package io.sweers.catchup.service.uplabs.model
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
-import org.threeten.bp.Instant
+import java.time.Instant
 
 @JsonClass(generateAdapter = true)
 internal data class UplabsImage(


### PR DESCRIPTION
Currently fails

```
./gradlew :app:assembleDebug                                                                                                                                 

> Transform artifact full.jar (project :services:dribbble) with DexingWithClasspathTransform
D8: Cannot generate a wrapper for final class java.time.temporal.ValueRange. Add a custom conversion in the desugared library.

> Task :app:mergeLibDexDebug FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:mergeLibDexDebug'.
> Could not resolve all files for configuration ':app:debugRuntimeClasspath'.
   > Failed to transform full.jar (project :services:dribbble) to match attributes {artifactType=android-dex, com.android.build.api.attributes.BuildTypeAttr=debug, com.android.build.api.attributes.VariantAttr=debug, com.android.build.gradle.internal.dependency.AndroidUsageAttr=android-build, dexing-enable-desugaring=true, dexing-is-debuggable=true, dexing-min-sdk=21, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime, org.jetbrains.kotlin.platform.type=androidJvm}.
      > Execution failed for DexingWithClasspathTransform: /Users/pandanomic/dev/android/personal/CatchUp/services/dribbble/build/.transforms/f0859405a43495a1a9dee65eab7adf02/jetified-full.jar.
         > Error while dexing.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.0-rc-1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD FAILED in 15s
428 actionable tasks: 2 executed, 426 up-to-date
```