### PR TITLE
WIP Dagger 2.25.2

### DIFF
--- a/app/src/debug/kotlin/io/sweers/catchup/app/DebugApplicationModule.kt
+++ b/app/src/debug/kotlin/io/sweers/catchup/app/DebugApplicationModule.kt
@@ -61,11 +61,9 @@ object DebugApplicationModule {
    * https://github.com/square/leakcanary/issues/1081
    */
   @LeakCanaryEnabled
-  @JvmStatic
   @Provides
   fun provideLeakCanaryEnabled(): Boolean = Build.VERSION.SDK_INT != 28
 
-  @JvmStatic
   @Provides
   fun provideObjectWatcher(@LeakCanaryEnabled leakCanaryEnabled: Boolean): CatchUpObjectWatcher {
     return if (leakCanaryEnabled) {
@@ -79,7 +77,6 @@ object DebugApplicationModule {
     }
   }
 
-  @JvmStatic
   @Provides
   fun provideLeakCanaryConfig(@LeakCanaryEnabled leakCanaryEnabled: Boolean): LeakCanary.Config {
     return if (leakCanaryEnabled) {
@@ -90,7 +87,6 @@ object DebugApplicationModule {
   }
 
   @Initializers
-  @JvmStatic
   @IntoSet
   @Provides
   fun leakCanaryInit(
@@ -131,12 +127,10 @@ object DebugApplicationModule {
   private annotation class StrictModeExecutor
 
   @StrictModeExecutor
-  @JvmStatic
   @Provides
   fun strictModeExecutor(): ExecutorService = Executors.newSingleThreadExecutor()
 
   @Initializers
-  @JvmStatic
   @IntoSet
   @Provides
   @SuppressLint("InlinedApi") // False positive
@@ -186,7 +180,6 @@ object DebugApplicationModule {
   private annotation class FlipperEnabled
 
   @FlipperEnabled
-  @JvmStatic
   @Provides
   fun provideFlipperEnabled(application: Application): Boolean {
     return if (Build.VERSION.SDK_INT == 28) {
@@ -198,7 +191,6 @@ object DebugApplicationModule {
   }
 
   @AsyncInitializers
-  @JvmStatic
   @IntoSet
   @Provides
   fun flipperInit(
@@ -215,17 +207,14 @@ object DebugApplicationModule {
     }
   }
 
-  @JvmStatic
   @IntoSet
   @Provides
   fun provideDebugTree(): Timber.Tree = Timber.DebugTree()
 
-  @JvmStatic
   @IntoSet
   @Provides
   fun provideLumberYardTree(lumberYard: LumberYard): Timber.Tree = lumberYard.tree()
 
-  @JvmStatic
   @IntoSet
   @Provides
   fun provideCrashOnErrorTree(flipperCrashReporter: CrashReporterPlugin): Timber.Tree {

--- a/app/src/debug/kotlin/io/sweers/catchup/app/DebugApplicationModule.kt
+++ b/app/src/debug/kotlin/io/sweers/catchup/app/DebugApplicationModule.kt
@@ -60,6 +60,7 @@ object DebugApplicationModule {
    * Disabled on API 28 because there's a pretty vicious memory leak that constantly triggers
    * https://github.com/square/leakcanary/issues/1081
    */
+  @JvmStatic // https://github.com/google/dagger/issues/1648
   @LeakCanaryEnabled
   @Provides
   fun provideLeakCanaryEnabled(): Boolean = Build.VERSION.SDK_INT != 28
@@ -179,6 +180,7 @@ object DebugApplicationModule {
   @Retention(BINARY)
   private annotation class FlipperEnabled
 
+  @JvmStatic // https://github.com/google/dagger/issues/1648
   @FlipperEnabled
   @Provides
   fun provideFlipperEnabled(application: Application): Boolean {

--- a/app/src/debug/kotlin/io/sweers/catchup/data/VariantDataModule.kt
+++ b/app/src/debug/kotlin/io/sweers/catchup/data/VariantDataModule.kt
@@ -42,7 +42,6 @@ object VariantDataModule {
   @Provides
   @NetworkInterceptor
   @IntoSet
-  @JvmStatic
   @Singleton
   internal fun provideLoggingInterceptor(): Interceptor = httpLoggingInterceptor(BASIC) { message ->
     Timber.tag("OkHttp")
@@ -52,14 +51,12 @@ object VariantDataModule {
 //  @Provides
 //  @NetworkInterceptor
 //  @IntoSet
-//  @JvmStatic
 //  @Singleton
 //  internal fun provideChuckInterceptor(@ApplicationContext context: Context): Interceptor =
 //      ChuckInterceptor(context)
 
   @Provides
   @IntoSet
-  @JvmStatic
   @Singleton
   internal fun provideMockDataInterceptor(
     @ApplicationContext context: Context,

--- a/app/src/debug/kotlin/io/sweers/catchup/ui/activity/UiModule.kt
+++ b/app/src/debug/kotlin/io/sweers/catchup/ui/activity/UiModule.kt
@@ -26,7 +26,6 @@ import io.sweers.catchup.ui.bugreport.BugReportModule
 object UiModule {
 
   @Provides
-  @JvmStatic
   @PerActivity
   internal fun provideViewContainer(viewContainer: DebugViewContainer): ViewContainer =
       viewContainer

--- a/app/src/debug/kotlin/io/sweers/catchup/ui/bugreport/BugReportApi.kt
+++ b/app/src/debug/kotlin/io/sweers/catchup/ui/bugreport/BugReportApi.kt
@@ -68,7 +68,6 @@ data class GitHubIssue(
 internal object BugReportModule {
 
   @Provides
-  @JvmStatic
   @PerActivity
   internal fun provideImgurService(
     client: Lazy<OkHttpClient>,
@@ -88,7 +87,6 @@ internal object BugReportModule {
   }
 
   @Provides
-  @JvmStatic
   @PerActivity
   internal fun provideGithubIssueService(
     client: Lazy<OkHttpClient>,

--- a/app/src/main/kotlin/io/sweers/catchup/data/GithubApolloModule.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/data/GithubApolloModule.kt
@@ -53,20 +53,17 @@ internal object GithubApolloModule {
    * TODO this hits disk on startup -_-
    */
   @Provides
-  @JvmStatic
   @Singleton
   internal fun provideHttpCacheStore(@ApplicationContext context: Context): HttpCacheStore =
       DiskLruHttpCacheStore(context.cacheDir, 1_000_000)
 
   @Provides
-  @JvmStatic
   @Singleton
   internal fun provideHttpCache(httpCacheStore: HttpCacheStore): HttpCache =
       ApolloHttpCache(httpCacheStore, null)
 
   @Provides
   @InternalApi
-  @JvmStatic
   @Singleton
   internal fun provideGitHubOkHttpClient(
     client: OkHttpClient,
@@ -77,7 +74,6 @@ internal object GithubApolloModule {
       .build()
 
   @Provides
-  @JvmStatic
   @Singleton
   internal fun provideCacheKeyResolver(): CacheKeyResolver = object : CacheKeyResolver() {
     private val formatter = { id: String ->
@@ -106,13 +102,11 @@ internal object GithubApolloModule {
   }
 
   @Provides
-  @JvmStatic
   @Singleton
   internal fun provideNormalizedCacheFactory(): NormalizedCacheFactory<*> =
       LruNormalizedCacheFactory(EvictionPolicy.NO_EVICTION)
 
   @Provides
-  @JvmStatic
   @Singleton
   internal fun provideApolloClient(
     @InternalApi client: Lazy<OkHttpClient>,

--- a/app/src/release/kotlin/io/sweers/catchup/app/ReleaseApplicationModule.kt
+++ b/app/src/release/kotlin/io/sweers/catchup/app/ReleaseApplicationModule.kt
@@ -30,7 +30,6 @@ import kotlin.annotation.AnnotationRetention.BINARY
 @Module
 object ReleaseApplicationModule {
 
-  @JvmStatic
   @Provides
   fun provideObjectWatcher(): CatchUpObjectWatcher = CatchUpObjectWatcher.None
 
@@ -39,19 +38,16 @@ object ReleaseApplicationModule {
   private annotation class BugsnagKey
 
   @BugsnagKey
-  @JvmStatic
   @Provides
   fun provideBugsnagKey(): String = BuildConfig.BUGSNAG_KEY
 
   @Initializers
-  @JvmStatic
   @IntoSet
   @Provides
   fun bugsnagInit(application: Application, @BugsnagKey key: String): () -> Unit = {
     Bugsnag.init(application, key)
   }
 
-  @JvmStatic
   @IntoSet
   @Provides
   fun provideBugsnagTree(): Timber.Tree = BugsnagTree().also {

--- a/app/src/release/kotlin/io/sweers/catchup/ui/activity/UiModule.kt
+++ b/app/src/release/kotlin/io/sweers/catchup/ui/activity/UiModule.kt
@@ -25,7 +25,6 @@ import io.sweers.catchup.injection.scopes.PerActivity
 object UiModule {
 
   @Provides
-  @JvmStatic
   @PerActivity
   internal fun provideViewContainer(): ViewContainer {
     return ViewContainer.DEFAULT

--- a/buildSrc/src/main/kotlin/dependencies.kt
+++ b/buildSrc/src/main/kotlin/dependencies.kt
@@ -66,7 +66,7 @@ object deps {
     const val autodispose = "1.4.0"
     const val chuck = "1.1.0"
     const val crumb = "0.1.0"
-    const val dagger = "2.24"
+    const val dagger = "2.25.2"
     const val espresso = "3.1.0-alpha1"
     const val hyperion = "0.9.24"
     const val inspector = "0.3.0"

--- a/libraries/gemoji/src/main/kotlin/io/sweers/catchup/gemoji/GemojiModule.kt
+++ b/libraries/gemoji/src/main/kotlin/io/sweers/catchup/gemoji/GemojiModule.kt
@@ -26,7 +26,6 @@ import javax.inject.Singleton
 object GemojiModule {
 
   @Provides
-  @JvmStatic
   @Singleton
   internal fun provideGemojiDatabase(@ApplicationContext context: Context): GemojiDatabase {
     return Room.databaseBuilder(context, GemojiDatabase::class.java, "gemoji.db")
@@ -36,14 +35,12 @@ object GemojiModule {
   }
 
   @Provides
-  @JvmStatic
   @Singleton
   internal fun provideGemojiDao(gemojiDatabase: GemojiDatabase): GemojiDao {
     return gemojiDatabase.gemojiDao()
   }
 
   @Provides
-  @JvmStatic
   @Singleton
   fun provideEmojiMarkdownConverter(gemojiDao: GemojiDao): EmojiMarkdownConverter {
     return GemojiEmojiMarkdownConverter(gemojiDao)

--- a/libraries/smmry/src/main/kotlin/io/sweers/catchup/smmry/SmmryModule.kt
+++ b/libraries/smmry/src/main/kotlin/io/sweers/catchup/smmry/SmmryModule.kt
@@ -37,7 +37,6 @@ object SmmryModule {
   annotation class ForSmmry
 
   @Provides
-  @JvmStatic
   @ForSmmry
   internal fun provideSmmryMoshi(moshi: Moshi): Moshi {
     return moshi.newBuilder()
@@ -46,7 +45,6 @@ object SmmryModule {
   }
 
   @Provides
-  @JvmStatic
   internal fun provideSmmryService(
     client: Lazy<OkHttpClient>,
     @ForSmmry moshi: Moshi
@@ -60,7 +58,6 @@ object SmmryModule {
   }
 
   @Provides
-  @JvmStatic
   internal fun provideDatabase(context: Context): SmmryDatabase {
     return Room.databaseBuilder(context.applicationContext,
         SmmryDatabase::class.java,
@@ -70,6 +67,5 @@ object SmmryModule {
   }
 
   @Provides
-  @JvmStatic
   internal fun provideSmmryDao(database: SmmryDatabase): SmmryDao = database.dao()
 }

--- a/services/hackernews/src/main/kotlin/io/sweers/catchup/service/hackernews/HackerNewsService.kt
+++ b/services/hackernews/src/main/kotlin/io/sweers/catchup/service/hackernews/HackerNewsService.kt
@@ -224,7 +224,6 @@ internal abstract class ViewModelModule {
 @Module
 internal object FragmentViewModelFactoryModule {
   @Provides
-  @JvmStatic
   fun viewModelFactory(
     viewModels: @JvmSuppressWildcards Map<Class<out ViewModel>, AssistedFactory>
   ): ViewModelProviderFactoryInstantiator {


### PR DESCRIPTION
Currently misses some object instance references

```
> Task :app:compileDebugJavaWithJavac FAILED
/Users/pandanomic/dev/android/personal/CatchUp/app/build/generated/source/kapt/debug/io/sweers/catchup/app/DaggerApplicationComponent.java:366: error: non-static method provideFlipperEnabled(Application) cannot be referenced from a static context
    return DebugApplicationModule.provideFlipperEnabled(application);}
                                 ^
/Users/pandanomic/dev/android/personal/CatchUp/app/build/generated/source/kapt/debug/io/sweers/catchup/app/DaggerApplicationComponent.java:384: error: non-static method provideLeakCanaryEnabled() cannot be referenced from a static context
    return DebugApplicationModule_ProvideObjectWatcherFactory.provideObjectWatcher(DebugApplicationModule.provideLeakCanaryEnabled());}
                                                                                                         ^
/Users/pandanomic/dev/android/personal/CatchUp/app/build/generated/source/kapt/debug/io/sweers/catchup/app/DaggerApplicationComponent.java:387: error: non-static method provideLeakCanaryEnabled() cannot be referenced from a static context
    return DebugApplicationModule_ProvideLeakCanaryConfigFactory.provideLeakCanaryConfig(DebugApplicationModule.provideLeakCanaryEnabled());}
                                                                                                               ^
3 errors

FAILURE: Build failed with an exception.

```