### PR TITLE
Introduce moshi-sealed

### DIFF
--- a/app/src/main/assets/licenses_github.json
+++ b/app/src/main/assets/licenses_github.json
@@ -61,7 +61,7 @@
   },
   {
     "owner": "ZacSweers",
-    "name": "Barber"
+    "name": "moshi-sealed"
   },
   {
     "owner": "ZacSweers",

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,7 +34,6 @@
   <string name="pref_theme_navbar">Theme navigation bar in pager.</string>
   <string name="title_activity_settings">Settings</string>
   <string name="title_activity_about">About</string>
-  <string name="summarizing">Summarizing…</string>
   <string name="clear_cache_success">Cleaned %s</string>
   <string name="connection_issue">Connection Problem</string>
   <string name="api_issue">API Problem</string>

--- a/buildSrc/src/main/kotlin/dependencies.kt
+++ b/buildSrc/src/main/kotlin/dependencies.kt
@@ -382,8 +382,14 @@ object deps {
   }
 
   object moshi {
+    const val adapters = "com.squareup.moshi:moshi-adapters:${versions.moshi}"
     const val core = "com.squareup.moshi:moshi:${versions.moshi}"
     const val compiler = "com.squareup.moshi:moshi-kotlin-codegen:${versions.moshi}"
+    object sealed {
+      private const val VERSION = "0.1.0"
+      const val annotations = "dev.zacsweers.moshisealed:moshi-sealed-annotations:${VERSION}"
+      const val compiler = "dev.zacsweers.moshisealed:moshi-sealed-codegen:${VERSION}"
+    }
   }
 
   object okhttp {

--- a/libraries/smmry/build.gradle.kts
+++ b/libraries/smmry/build.gradle.kts
@@ -69,6 +69,7 @@ kapt {
 dependencies {
   kapt(deps.dagger.apt.compiler)
   kapt(deps.dagger.android.apt.processor)
+  kapt(deps.moshi.sealed.compiler)
   compileOnly(deps.misc.javaxInject)
   implementation(deps.dagger.runtime)
   implementation(deps.dagger.android.runtime)
@@ -80,7 +81,9 @@ dependencies {
   implementation(project(":libraries:util"))
   implementation(deps.misc.lottie)
   kapt(deps.moshi.compiler)
+  implementation(deps.moshi.adapters)
   implementation(deps.moshi.core)
+  implementation(deps.moshi.sealed.annotations)
   implementation(deps.android.androidx.room.runtime)
   implementation(deps.android.androidx.room.ktx)
   kapt(deps.android.androidx.room.apt)

--- a/libraries/smmry/src/main/kotlin/io/sweers/catchup/smmry/model/SmmryResponse.kt
+++ b/libraries/smmry/src/main/kotlin/io/sweers/catchup/smmry/model/SmmryResponse.kt
@@ -37,26 +37,26 @@ sealed class SmmryResponse {
   @JsonClass(generateAdapter = true)
   data class Success(
 
-      /**
-       * Contains the amount of characters returned
-       */
-      @Json(name = "sm_api_character_count") val characterCount: String,
+    /**
+     * Contains the amount of characters returned
+     */
+    @Json(name = "sm_api_character_count") val characterCount: String,
 
-      /**
-       * Contains the title when available
-       */
-      @Json(name = "sm_api_title")
-      @UnEscape val title: String,
+    /**
+     * Contains the title when available
+     */
+    @Json(name = "sm_api_title")
+    @UnEscape val title: String,
 
-      /**
-       * Contains the summary
-       */
-      @Json(name = "sm_api_content") val content: String,
+    /**
+     * Contains the summary
+     */
+    @Json(name = "sm_api_content") val content: String,
 
-      /**
-       * Contains top ranked keywords in descending order
-       */
-      @Json(name = "sm_api_keyword_array") val keywords: List<String>? = null
+    /**
+     * Contains top ranked keywords in descending order
+     */
+    @Json(name = "sm_api_keyword_array") val keywords: List<String>? = null
   ) : SmmryResponse() {
 
     companion object {
@@ -80,35 +80,34 @@ sealed class SmmryResponse {
     @TypeLabel("0")
     @JsonClass(generateAdapter = true)
     data class InternalError(
-        @Json(name = ERROR_MESSAGE) val message: String
+      @Json(name = ERROR_MESSAGE) val message: String
     ) : Failure("Smmry internal error - $message")
 
     // 1 - Incorrect submission variables
     @TypeLabel("1")
     @JsonClass(generateAdapter = true)
     data class IncorrectVariables(
-        @Json(name = ERROR_MESSAGE) val message: String
+      @Json(name = ERROR_MESSAGE) val message: String
     ) : Failure("Smmry invalid input - $message")
 
     // 2 - Intentional restriction (low credits/disabled API key/banned API key)
     @TypeLabel("2")
     @JsonClass(generateAdapter = true)
     data class ApiRejection(
-        @Json(name = ERROR_MESSAGE) val message: String
+      @Json(name = ERROR_MESSAGE) val message: String
     ) : Failure("Smmry API error - $message")
 
     // 3 - Summarization error
     @TypeLabel("3")
     @JsonClass(generateAdapter = true)
     data class SummarizationError(
-        @Json(name = ERROR_MESSAGE) val message: String
+      @Json(name = ERROR_MESSAGE) val message: String
     ) : Failure("Smmry summarization error - $message")
 
     @DefaultObject
     object UnknownErrorCode : Failure("Unknown error.")
   }
 }
-
 
 class SmmryResponseFactory : JsonAdapter.Factory {
 

--- a/libraries/smmry/src/main/res/layout/fragment_smmry.xml
+++ b/libraries/smmry/src/main/res/layout/fragment_smmry.xml
@@ -52,11 +52,9 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
-        android:fontFamily="@font/nunito"
         android:gravity="center_horizontal"
         android:text="@string/summarizing"
         android:textAppearance="@style/TextAppearance.AppCompat.Title"
-        app:fontFamily="@font/nunito"
         />
   </LinearLayout>
 
@@ -79,9 +77,7 @@
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:layout_marginBottom="8dp"
-          android:fontFamily="@font/nunito"
           android:gravity="center_horizontal"
-          app:fontFamily="@font/nunito"
           style="@style/TextAppearance.AppCompat.Title"
           />
 
@@ -90,9 +86,7 @@
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:layout_marginBottom="16dp"
-          android:fontFamily="@font/nunito"
           android:gravity="center_horizontal"
-          app:fontFamily="@font/nunito"
           style="@style/TextAppearance.AppCompat.Caption"
           />
 
@@ -100,10 +94,8 @@
           android:id="@+id/summary"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:fontFamily="@font/nunito"
           android:textAppearance="@style/TextAppearance.AppCompat.Body1"
           android:textIsSelectable="true"
-          app:fontFamily="@font/nunito"
           />
 
     </LinearLayout>

--- a/libraries/smmry/src/main/res/values/strings.xml
+++ b/libraries/smmry/src/main/res/values/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2019 Zac Sweers
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources>
+  <string name="summarizing">Summarizing…</string>
+</resources>


### PR DESCRIPTION
This replaces some of the manual parsing for Smmry responses to a new sealed failure type hierarchy using Moshi-sealed.

Some things I wish went better:

Having to redeclare the same property + `@Json` annotation in every subtype is annoying, but required for Moshi

Polymorphic adapter covers one specific case: every type having a type label. There are other cases though:
A. Smmry is a case of "if this error key is present, the whole thing is this an error type. Otherwise it's success"
B. Reddit has data in one level deeper. One level is `type` and `data`, where `type` informs what class the `data` field should be deserialized as.

A solution could be to accept an enum of known styles in the polymorphic adapter. Style A could basically have a "default" subtype or type label per-subtype. Style B could have some "nested()" key that the subtype is deserialized as. Both of these are super specific, but then again so is the first-party solution.