### PR TITLE
Remove now-unnecessary injection field qualifiers

### DIFF
--- a/app/src/main/kotlin/io/sweers/catchup/ui/fragments/service/ServiceFragment.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/ui/fragments/service/ServiceFragment.kt
@@ -163,13 +163,13 @@ class ServiceFragment : InjectingBaseFragment(),
 
   @Inject
   internal lateinit var linkManager: LinkManager
-  @field:TextViewPool
+  @TextViewPool
   @Inject
   lateinit var textViewPool: RecycledViewPool
-  @field:VisualViewPool
+  @VisualViewPool
   @Inject
   lateinit var visualViewPool: RecycledViewPool
-  @field:FinalServices
+  @FinalServices
   @Inject
   lateinit var services: Map<String, @JvmSuppressWildcards Provider<Service>>
   private lateinit var service: Service

--- a/libraries/smmry/src/main/kotlin/io/sweers/catchup/smmry/SmmryFragment.kt
+++ b/libraries/smmry/src/main/kotlin/io/sweers/catchup/smmry/SmmryFragment.kt
@@ -87,7 +87,7 @@ class SmmryFragment : InjectableBaseFragment(), ScrollableContent {
 
   @Inject
   lateinit var smmryService: SmmryService
-  @field:ForSmmry
+  @ForSmmry
   @Inject
   lateinit var moshi: Moshi
   @Inject


### PR DESCRIPTION
With dagger's newer kotlin support, this isn't needed anymore 👌