### PR TITLE
Build on jdk 8 and 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
             ${{ runner.os }}-gradlebuildcache-
 
       - name: Build with Gradle
-        run: ./gradlew spotlessCheck :app:assembleDebug test check
+        run: ./gradlew spotlessCheck :app:assembleDebug test check --stacktrace
 #      - name: Upload alpha APK to play store (master only)
 #        run: CATCHUP_SIGNING_ENCRYPT_KEY=${{ secrets.CatchupSigningEncryptKey }} CATCHUP_P12_ENCRYPT_KEY=${{ secrets.CatchupP12EncryptKey }} ./createRelease.sh
 #        if: success() && github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && matrix.java_version == '1.8'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,8 @@ jobs:
     strategy:
       matrix:
         # TODO Add 12 and 13 after Kotlin 1.3.70
-        java_version: [1.8, 9, 10, 11]
+        # Can't use 9 because Kapt doesn't work on it with certain zips -_-
+        java_version: [1.8, 10, 11]
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # TODO Add 9, 10, 11, 12, and 13 after Kotlin 1.3.70
-        java_version: [1.8]
+        # TODO Add 12 and 13 after Kotlin 1.3.70
+        java_version: [1.8, 9, 10, 11]
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,8 @@ jobs:
       matrix:
         # TODO Add 12 and 13 after Kotlin 1.3.70
         # Can't use 9 because Kapt doesn't work on it with certain zips -_-
-        java_version: [1.8, 10, 11]
+        # Can't use 10 because it has all sort of bizarre Generated annotation issues -_-
+        java_version: [1.8, 11]
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -217,12 +217,6 @@ kapt {
     arg("room.incremental", "true")
     arg("moshi.generated", "javax.annotation.Generated")
   }
-
-  // Compiling with JDK 11+, but kapt doesn't forward source/target versions.
-  javacOptions {
-    option("-source", "8")
-    option("-target", "8")
-  }
 }
 
 play {

--- a/app/src/main/kotlin/io/sweers/catchup/ui/fragments/PagerFragment.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/ui/fragments/PagerFragment.kt
@@ -89,7 +89,7 @@ class PagerFragment : InjectingBaseFragment<FragmentPagerBinding>() {
   }
 
   @Inject
-  lateinit var resolvedColorCache: IntArray
+  lateinit var resolvedColorCache: ColorCache
   @Inject
   lateinit var serviceHandlers: Array<ServiceHandler>
   @Inject
@@ -374,7 +374,15 @@ class PagerFragment : InjectingBaseFragment<FragmentPagerBinding>() {
 
     @JvmStatic
     @Provides
-    fun provideColorCache(serviceHandlers: Array<ServiceHandler>) = IntArray(
-        serviceHandlers.size).apply { fill(R.color.no_color) }
+    fun provideColorCache(serviceHandlers: Array<ServiceHandler>) = ColorCache(IntArray(
+        serviceHandlers.size).apply { fill(R.color.no_color) })
+  }
+}
+
+// TODO This is cover for https://github.com/google/dagger/issues/1593
+class ColorCache(val cache: IntArray) {
+  operator fun get(index: Int) = cache[index]
+  operator fun set(index: Int, value: Int) {
+    cache[index] = value
   }
 }

--- a/buildSrc/src/main/kotlin/dependencies.kt
+++ b/buildSrc/src/main/kotlin/dependencies.kt
@@ -369,6 +369,7 @@ object deps {
     const val inboxRecyclerView = "me.saket:inboxrecyclerview:2.0.0-beta3"
     const val javaxInject = "org.glassfish:javax.annotation:10.0-b28"
     const val jsoup = "org.jsoup:jsoup:1.12.1"
+    const val jsr250 = "javax.annotation:jsr250-api:1.0"
     const val jsr305 = "com.google.code.findbugs:jsr305:3.0.2"
     const val kotpref = "com.chibatching.kotpref:kotpref:${versions.kotpref}"
     const val kotprefEnum = "com.chibatching.kotpref:enum-support:${versions.kotpref}"

--- a/buildSrc/src/main/kotlin/dependencies.kt
+++ b/buildSrc/src/main/kotlin/dependencies.kt
@@ -155,7 +155,7 @@ object deps {
       const val perf = "com.google.firebase:firebase-perf:18.0.0"
     }
 
-    const val gradlePlugin = "com.android.tools.build:gradle:4.0.0-alpha03"
+    const val gradlePlugin = "com.android.tools.build:gradle:4.0.0-alpha04"
   }
 
   object apollo {
@@ -167,7 +167,7 @@ object deps {
   }
 
   object assistedInject {
-    private const val version = "0.5.1"
+    private const val version = "0.5.2"
     const val annotations = "com.squareup.inject:assisted-inject-annotations-dagger2:$version"
     const val processor = "com.squareup.inject:assisted-inject-processor-dagger2:$version"
   }

--- a/libraries/base-ui/build.gradle.kts
+++ b/libraries/base-ui/build.gradle.kts
@@ -56,12 +56,6 @@ android {
 kapt {
   correctErrorTypes = true
   mapDiagnosticLocations = true
-
-  // Compiling with JDK 11+, but kapt doesn't forward source/target versions.
-  javacOptions {
-    option("-source", "8")
-    option("-target", "8")
-  }
 }
 
 dependencies {

--- a/libraries/gemoji/build.gradle.kts
+++ b/libraries/gemoji/build.gradle.kts
@@ -69,6 +69,7 @@ dependencies {
 
   kapt(deps.android.androidx.room.apt)
   kapt(deps.dagger.apt.compiler)
+  compileOnly(deps.misc.jsr250)
 
   api(deps.android.androidx.room.runtime)
   api(deps.dagger.runtime)

--- a/libraries/gemoji/build.gradle.kts
+++ b/libraries/gemoji/build.gradle.kts
@@ -62,12 +62,6 @@ kapt {
     arg("room.schemaLocation", "$projectDir/schemas")
     arg("room.incremental", "true")
   }
-
-  // Compiling with JDK 11+, but kapt doesn't forward source/target versions.
-  javacOptions {
-    option("-source", "8")
-    option("-target", "8")
-  }
 }
 
 dependencies {

--- a/libraries/smmry/build.gradle.kts
+++ b/libraries/smmry/build.gradle.kts
@@ -61,12 +61,6 @@ kapt {
     arg("room.incremental", "true")
     arg("moshi.generated", "javax.annotation.Generated")
   }
-
-  // Compiling with JDK 11+, but kapt doesn't forward source/target versions.
-  javacOptions {
-    option("-source", "8")
-    option("-target", "8")
-  }
 }
 
 dependencies {

--- a/services/designernews/build.gradle.kts
+++ b/services/designernews/build.gradle.kts
@@ -62,12 +62,6 @@ kapt {
   arguments {
     arg("moshi.generated", "javax.annotation.Generated")
   }
-
-  // Compiling with JDK 11+, but kapt doesn't forward source/target versions.
-  javacOptions {
-    option("-source", "8")
-    option("-target", "8")
-  }
 }
 
 dependencies {

--- a/services/dribbble/build.gradle.kts
+++ b/services/dribbble/build.gradle.kts
@@ -59,12 +59,6 @@ tasks.withType<KotlinCompile> {
 kapt {
   correctErrorTypes = true
   mapDiagnosticLocations = true
-
-  // Compiling with JDK 11+, but kapt doesn't forward source/target versions.
-  javacOptions {
-    option("-source", "8")
-    option("-target", "8")
-  }
 }
 
 dependencies {

--- a/services/github/build.gradle.kts
+++ b/services/github/build.gradle.kts
@@ -63,12 +63,6 @@ tasks.withType<KotlinCompile> {
 kapt {
   correctErrorTypes = true
   mapDiagnosticLocations = true
-
-  // Compiling with JDK 11+, but kapt doesn't forward source/target versions.
-  javacOptions {
-    option("-source", "8")
-    option("-target", "8")
-  }
 }
 
 apollo {

--- a/services/hackernews/build.gradle.kts
+++ b/services/hackernews/build.gradle.kts
@@ -67,12 +67,6 @@ tasks.withType<KotlinCompile> {
 kapt {
   correctErrorTypes = true
   mapDiagnosticLocations = true
-
-  // Compiling with JDK 11+, but kapt doesn't forward source/target versions.
-  javacOptions {
-    option("-source", "8")
-    option("-target", "8")
-  }
 }
 
 dependencies {

--- a/services/imgur/build.gradle.kts
+++ b/services/imgur/build.gradle.kts
@@ -59,12 +59,6 @@ kapt {
   arguments {
     arg("moshi.generated", "javax.annotation.Generated")
   }
-
-  // Compiling with JDK 11+, but kapt doesn't forward source/target versions.
-  javacOptions {
-    option("-source", "8")
-    option("-target", "8")
-  }
 }
 
 dependencies {

--- a/services/medium/build.gradle.kts
+++ b/services/medium/build.gradle.kts
@@ -62,12 +62,6 @@ kapt {
   arguments {
     arg("moshi.generated", "javax.annotation.Generated")
   }
-
-  // Compiling with JDK 11+, but kapt doesn't forward source/target versions.
-  javacOptions {
-    option("-source", "8")
-    option("-target", "8")
-  }
 }
 
 dependencies {

--- a/services/newsapi/build.gradle.kts
+++ b/services/newsapi/build.gradle.kts
@@ -59,12 +59,6 @@ kapt {
   arguments {
     arg("moshi.generated", "javax.annotation.Generated")
   }
-
-  // Compiling with JDK 11+, but kapt doesn't forward source/target versions.
-  javacOptions {
-    option("-source", "8")
-    option("-target", "8")
-  }
 }
 
 dependencies {

--- a/services/producthunt/build.gradle.kts
+++ b/services/producthunt/build.gradle.kts
@@ -65,12 +65,6 @@ kapt {
   arguments {
     arg("moshi.generated", "javax.annotation.Generated")
   }
-
-  // Compiling with JDK 11+, but kapt doesn't forward source/target versions.
-  javacOptions {
-    option("-source", "8")
-    option("-target", "8")
-  }
 }
 
 dependencies {

--- a/services/reddit/build.gradle.kts
+++ b/services/reddit/build.gradle.kts
@@ -62,12 +62,6 @@ kapt {
   arguments {
     arg("moshi.generated", "javax.annotation.Generated")
   }
-
-  // Compiling with JDK 11+, but kapt doesn't forward source/target versions.
-  javacOptions {
-    option("-source", "8")
-    option("-target", "8")
-  }
 }
 
 dependencies {

--- a/services/slashdot/build.gradle.kts
+++ b/services/slashdot/build.gradle.kts
@@ -59,12 +59,6 @@ tasks.withType<KotlinCompile> {
 kapt {
   correctErrorTypes = true
   mapDiagnosticLocations = true
-
-  // Compiling with JDK 11+, but kapt doesn't forward source/target versions.
-  javacOptions {
-    option("-source", "8")
-    option("-target", "8")
-  }
 }
 
 dependencies {

--- a/services/unsplash/build.gradle.kts
+++ b/services/unsplash/build.gradle.kts
@@ -62,12 +62,6 @@ tasks.withType<KotlinCompile> {
 kapt {
   correctErrorTypes = true
   mapDiagnosticLocations = true
-
-  // Compiling with JDK 11+, but kapt doesn't forward source/target versions.
-  javacOptions {
-    option("-source", "8")
-    option("-target", "8")
-  }
 }
 
 dependencies {

--- a/services/uplabs/build.gradle.kts
+++ b/services/uplabs/build.gradle.kts
@@ -59,12 +59,6 @@ tasks.withType<KotlinCompile> {
 kapt {
   correctErrorTypes = true
   mapDiagnosticLocations = true
-
-  // Compiling with JDK 11+, but kapt doesn't forward source/target versions.
-  javacOptions {
-    option("-source", "8")
-    option("-target", "8")
-  }
 }
 
 dependencies {


### PR DESCRIPTION
This _shouldn't_ be necessary now, but building on JDK 11 still fails with or without these 🤔

```
> Task :services:hackernews:compileDebugJavaWithJavac FAILED
/Users/zsweers/dev/android/personal/CatchUp/services/hackernews/build/generated/source/kapt/debug/io/sweers/catchup/service/hackernews/AssistedInject_ViewModelModule.java:6: error: package javax.annotation.processing does not exist
import javax.annotation.processing.Generated;
                                  ^
/Users/zsweers/dev/android/personal/CatchUp/services/hackernews/build/generated/source/kapt/debug/io/sweers/catchup/service/hackernews/AssistedInject_ViewModelModule.java:9: error: cannot find symbol
@Generated(
 ^
  symbol: class Generated
/Users/zsweers/dev/android/personal/CatchUp/services/hackernews/build/generated/source/kapt/debug/io/sweers/catchup/service/hackernews/HackerNewsCommentsViewModel_AssistedFactory.java:7: error: package javax.annotation.processing does not exist
import javax.annotation.processing.Generated;
                                  ^
/Users/zsweers/dev/android/personal/CatchUp/services/hackernews/build/generated/source/kapt/debug/io/sweers/catchup/service/hackernews/HackerNewsCommentsViewModel_AssistedFactory.java:11: error: cannot find symbol
@Generated(
 ^
  symbol: class Generated
4 errors
```