### PR TITLE
Add back missing scopes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
-      - uses: actions/cache@v1.1.2
+      - uses: actions/cache@v2
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('checksum.txt') }}

--- a/app/src/debug/kotlin/io/sweers/catchup/data/VariantDataModule.kt
+++ b/app/src/debug/kotlin/io/sweers/catchup/data/VariantDataModule.kt
@@ -28,6 +28,7 @@ import okhttp3.logging.HttpLoggingInterceptor
 import okhttp3.logging.HttpLoggingInterceptor.Level.BASIC
 import okhttp3.logging.HttpLoggingInterceptor.Logger
 import timber.log.Timber
+import javax.inject.Singleton
 
 private inline fun httpLoggingInterceptor(level: HttpLoggingInterceptor.Level = HttpLoggingInterceptor.Level.NONE, crossinline logger: (String) -> Unit): HttpLoggingInterceptor {
   return HttpLoggingInterceptor(object : Logger {
@@ -41,6 +42,7 @@ private inline fun httpLoggingInterceptor(level: HttpLoggingInterceptor.Level = 
 @Module
 object VariantDataModule {
 
+  @Singleton
   @Provides
   @NetworkInterceptor
   @IntoSet
@@ -50,11 +52,13 @@ object VariantDataModule {
   }
 
 //  @Provides
+//  @Singleton
 //  @NetworkInterceptor
 //  @IntoSet
 //  internal fun provideChuckInterceptor(@ApplicationContext context: Context): Interceptor =
 //      ChuckInterceptor(context)
 
+  @Singleton
   @Provides
   @IntoSet
   internal fun provideMockDataInterceptor(

--- a/app/src/debug/kotlin/io/sweers/catchup/flipper/FlipperModule.kt
+++ b/app/src/debug/kotlin/io/sweers/catchup/flipper/FlipperModule.kt
@@ -35,6 +35,7 @@ import io.sweers.catchup.injection.SharedPreferencesName
 import io.sweers.catchup.util.injection.qualifiers.ApplicationContext
 import io.sweers.catchup.util.injection.qualifiers.NetworkInterceptor
 import okhttp3.Interceptor
+import javax.inject.Singleton
 
 @InstallIn(ApplicationComponent::class)
 @Module
@@ -45,6 +46,7 @@ abstract class FlipperModule {
 
   @Binds
   @IntoSet
+  @Singleton
   abstract fun provideNetworkFlipperPluginIntoSet(plugin: NetworkFlipperPlugin): FlipperPlugin
 
   companion object {
@@ -65,6 +67,7 @@ abstract class FlipperModule {
     }
 
     @Provides
+    @Singleton
     fun provideOkHttpInspectorPlugin(): NetworkFlipperPlugin {
       return NetworkFlipperPlugin()
     }
@@ -85,6 +88,7 @@ abstract class FlipperModule {
     }
 
     @Provides
+    @Singleton
     fun provideFlipperCrashReporterPlugin(): CrashReporterPlugin = CrashReporterPlugin.getInstance()
   }
 }

--- a/app/src/debug/kotlin/io/sweers/catchup/ui/activity/UiModule.kt
+++ b/app/src/debug/kotlin/io/sweers/catchup/ui/activity/UiModule.kt
@@ -19,6 +19,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ActivityComponent
+import dagger.hilt.android.scopes.ActivityScoped
 import io.sweers.catchup.base.ui.ViewContainer
 import io.sweers.catchup.ui.DebugViewContainer
 import io.sweers.catchup.ui.bugreport.BugReportModule
@@ -27,6 +28,7 @@ import io.sweers.catchup.ui.bugreport.BugReportModule
 @Module(includes = [BugReportModule::class])
 object UiModule {
 
+  @ActivityScoped
   @Provides
   internal fun provideViewContainer(viewContainer: DebugViewContainer): ViewContainer =
       viewContainer

--- a/app/src/debug/kotlin/io/sweers/catchup/ui/bugreport/BugReportApi.kt
+++ b/app/src/debug/kotlin/io/sweers/catchup/ui/bugreport/BugReportApi.kt
@@ -23,6 +23,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ActivityComponent
+import dagger.hilt.android.scopes.ActivityScoped
 import dev.zacsweers.catchup.appconfig.AppConfig
 import io.reactivex.Single
 import io.sweers.catchup.BuildConfig
@@ -70,6 +71,7 @@ data class GitHubIssue(
 @Module
 internal object BugReportModule {
 
+  @ActivityScoped
   @Provides
   internal fun provideImgurService(
     client: Lazy<OkHttpClient>,
@@ -89,6 +91,7 @@ internal object BugReportModule {
         .create(ImgurUploadApi::class.java)
   }
 
+  @ActivityScoped
   @Provides
   internal fun provideGithubIssueService(
     client: Lazy<OkHttpClient>,

--- a/app/src/main/kotlin/io/sweers/catchup/app/ApplicationModule.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/app/ApplicationModule.kt
@@ -64,6 +64,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import timber.log.Timber
 import javax.inject.Qualifier
+import javax.inject.Singleton
 import kotlin.annotation.AnnotationRetention.BINARY
 
 @InstallIn(ApplicationComponent::class)
@@ -107,12 +108,15 @@ abstract class ApplicationModule {
 
   @Binds
   @ApplicationContext
+  @Singleton
   abstract fun provideApplicationContext(application: Application): Context
 
   @Binds
+  @Singleton
   abstract fun provideUiPreferences(catchupPreferences: CatchUpPreferences): UiPreferences
 
   @Binds
+  @Singleton
   abstract fun bindAppConfig(catchUpAppConfig: CatchUpAppConfig): AppConfig
 
   companion object {
@@ -123,12 +127,15 @@ abstract class ApplicationModule {
      * Wrapped so no one can try to cast it as an Application.
      */
     @Provides
+    @Singleton
     internal fun provideGeneralUseContext(@ApplicationContext appContext: Context): Context = ContextWrapper(appContext)
 
     @Provides
+    @Singleton
     internal fun versionInfo(@ApplicationContext appContext: Context): VersionInfo = appContext.versionInfo
 
     @Provides
+    @Singleton
     internal fun markwon(
       @LazyDelegate imageLoader: ImageLoader,
       @ApplicationContext context: Context, // TODO should use themed one from activity?
@@ -174,6 +181,7 @@ abstract class ApplicationModule {
 
     @IsLowRamDevice
     @Provides
+    @Singleton
     fun isLowRam(@ApplicationContext context: Context): Boolean {
       // Prefer higher quality images unless we're on a low RAM device
       return context.getSystemService<ActivityManager>()?.let {
@@ -183,10 +191,12 @@ abstract class ApplicationModule {
 
     @CoilOkHttpStack
     @Provides
+    @Singleton
     fun coilCache(@ApplicationContext context: Context): Cache = createDefaultCache(context)
 
     @CoilOkHttpStack
     @Provides
+    @Singleton
     fun coilHttpClient(
       okHttpClient: OkHttpClient,
       @CoilOkHttpStack cache: Cache
@@ -198,6 +208,7 @@ abstract class ApplicationModule {
 
     @Provides
     @LazyDelegate
+    @Singleton
     fun lazyImageLoader(imageLoader: dagger.Lazy<ImageLoader>): ImageLoader {
       return object : ImageLoader {
         override val defaults: DefaultRequestOptions
@@ -226,6 +237,7 @@ abstract class ApplicationModule {
     }
 
     @Provides
+    @Singleton
     fun imageLoader(
       @ApplicationContext context: Context,
       @IsLowRamDevice isLowRamDevice: Boolean,

--- a/app/src/main/kotlin/io/sweers/catchup/data/DataModule.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/data/DataModule.kt
@@ -41,6 +41,7 @@ import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import java.util.concurrent.TimeUnit
+import javax.inject.Singleton
 
 @InstallIn(ApplicationComponent::class)
 @Module(includes = [GithubApolloModule::class, GemojiModule::class])
@@ -59,6 +60,7 @@ abstract class DataModule {
     private const val HTTP_TIMEOUT_S = 30
 
     @Provides
+    @Singleton
     internal fun provideCache(@ApplicationContext context: Context): Cache {
       if (Looper.myLooper() == Looper.getMainLooper()) {
         throw IllegalStateException("Cache initialized on main thread.")
@@ -67,6 +69,7 @@ abstract class DataModule {
     }
 
     @Provides
+    @Singleton
     internal fun provideOkHttpClient(
       cache: Cache,
       interceptors: DaggerSet<Interceptor>,
@@ -90,6 +93,7 @@ abstract class DataModule {
     }
 
     @Provides
+    @Singleton
     internal fun provideMoshi(appConfig: AppConfig): Moshi {
       return Moshi.Builder()
           .apply {
@@ -106,27 +110,32 @@ abstract class DataModule {
     }
 
     @Provides
+    @Singleton
     internal fun provideRxJavaCallAdapterFactory(): RxJava2CallAdapterFactory {
       return RxJava2CallAdapterFactory.createWithScheduler(Schedulers.io())
     }
 
     @Provides
     @SharedPreferencesName
+    @Singleton
     fun provideSharedPreferencesName(): String {
       return "catchup"
     }
 
     @Provides
+    @Singleton
     fun provideSharedPreferences(@ApplicationContext context: Context, @SharedPreferencesName name: String): SharedPreferences {
       return context.getSharedPreferences(name, Context.MODE_PRIVATE)
     }
 
     @Provides
+    @Singleton
     internal fun provideCatchUpDatabase(@ApplicationContext context: Context): CatchUpDatabase {
       return CatchUpDatabase.getDatabase(context)
     }
 
     @Provides
+    @Singleton
     internal fun provideServiceDao(catchUpDatabase: CatchUpDatabase): ServiceDao {
       return catchUpDatabase.serviceDao()
     }

--- a/app/src/main/kotlin/io/sweers/catchup/data/GithubApolloModule.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/data/GithubApolloModule.kt
@@ -41,6 +41,7 @@ import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Response
 import javax.inject.Qualifier
+import javax.inject.Singleton
 
 @InstallIn(ApplicationComponent::class)
 @Module
@@ -55,15 +56,18 @@ internal object GithubApolloModule {
    * TODO this hits disk on startup -_-
    */
   @Provides
+  @Singleton
   internal fun provideHttpCacheStore(@ApplicationContext context: Context): HttpCacheStore =
       DiskLruHttpCacheStore(context.cacheDir, 1_000_000)
 
   @Provides
+  @Singleton
   internal fun provideHttpCache(httpCacheStore: HttpCacheStore): HttpCache =
       ApolloHttpCache(httpCacheStore, null)
 
   @Provides
   @InternalApi
+  @Singleton
   internal fun provideGitHubOkHttpClient(
     client: OkHttpClient,
     httpCache: HttpCache
@@ -73,6 +77,7 @@ internal object GithubApolloModule {
       .build()
 
   @Provides
+  @Singleton
   internal fun provideCacheKeyResolver(): CacheKeyResolver = object : CacheKeyResolver() {
     private val formatter = { id: String ->
       if (id.isEmpty()) {
@@ -100,10 +105,12 @@ internal object GithubApolloModule {
   }
 
   @Provides
+  @Singleton
   internal fun provideNormalizedCacheFactory(): NormalizedCacheFactory<*> =
       LruNormalizedCacheFactory(EvictionPolicy.NO_EVICTION)
 
   @Provides
+  @Singleton
   internal fun provideApolloClient(
     @InternalApi client: Lazy<OkHttpClient>,
     cacheFactory: NormalizedCacheFactory<*>,

--- a/app/src/main/kotlin/io/sweers/catchup/injection/ActivityModules.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/injection/ActivityModules.kt
@@ -21,11 +21,13 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ActivityComponent
+import dagger.hilt.android.scopes.ActivityScoped
 import io.sweers.catchup.ui.activity.MainActivity
 
 @InstallIn(ActivityComponent::class)
 @Module
 object ComponentActivityModule {
+  @ActivityScoped
   @Provides
   fun provideComponentActivity(activity: Activity): ComponentActivity {
     return activity as ComponentActivity
@@ -36,6 +38,7 @@ object ComponentActivityModule {
 @InstallIn(ActivityComponent::class)
 @Module
 object MainActivityModule {
+  @ActivityScoped
   @Provides
   fun provideComponentActivity(activity: Activity): MainActivity {
     return activity as MainActivity

--- a/app/src/main/kotlin/io/sweers/catchup/ui/activity/MainActivity.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/ui/activity/MainActivity.kt
@@ -103,14 +103,17 @@ class MainActivity : InjectingBaseActivity() {
   @dagger.Module(includes = [ResolvedCatchUpServiceRegistry::class])
   abstract class ServiceIntegrationModule {
     companion object {
+      @ActivityScoped
       @TextViewPool
       @Provides
       fun provideTextViewPool() = RecycledViewPool()
 
+      @ActivityScoped
       @VisualViewPool
       @Provides
       fun provideVisualViewPool() = RecycledViewPool()
 
+      @ActivityScoped
       @Provides
       @FinalServices
       fun provideFinalServices(
@@ -140,12 +143,15 @@ class MainActivity : InjectingBaseActivity() {
     @Multibinds
     abstract fun fragmentCreators(): DaggerMap<Class<out Fragment>, Fragment>
 
+    @ActivityScoped
     @Binds
     abstract fun provideLinkHandler(linkManager: LinkManager): LinkHandler
 
+    @ActivityScoped
     @Binds
     abstract fun provideDetailDisplayer(mainActivityDetailDisplayer: MainActivityDetailDisplayer): DetailDisplayer
 
+    @ActivityScoped
     @Binds
     abstract fun provideFragmentFactory(fragmentFactory: MainActivityFragmentFactory): FragmentFactory
   }

--- a/app/src/release/kotlin/io/sweers/catchup/app/ReleaseApplicationModule.kt
+++ b/app/src/release/kotlin/io/sweers/catchup/app/ReleaseApplicationModule.kt
@@ -27,6 +27,7 @@ import io.sweers.catchup.app.ApplicationModule.Initializers
 import io.sweers.catchup.base.ui.CatchUpObjectWatcher
 import timber.log.Timber
 import javax.inject.Qualifier
+import javax.inject.Singleton
 import kotlin.annotation.AnnotationRetention.BINARY
 
 @InstallIn(ApplicationComponent::class)
@@ -34,6 +35,7 @@ import kotlin.annotation.AnnotationRetention.BINARY
 object ReleaseApplicationModule {
 
   @Provides
+  @Singleton
   fun provideObjectWatcher(): CatchUpObjectWatcher = CatchUpObjectWatcher.None
 
   @Qualifier
@@ -42,6 +44,7 @@ object ReleaseApplicationModule {
 
   @BugsnagKey
   @Provides
+  @Singleton
   fun provideBugsnagKey(): String = BuildConfig.BUGSNAG_KEY
 
   @Initializers

--- a/app/src/release/kotlin/io/sweers/catchup/ui/activity/UiModule.kt
+++ b/app/src/release/kotlin/io/sweers/catchup/ui/activity/UiModule.kt
@@ -19,12 +19,14 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ActivityComponent
+import dagger.hilt.android.scopes.ActivityScoped
 import io.sweers.catchup.base.ui.ViewContainer
 
 @InstallIn(ActivityComponent::class)
 @Module
 object UiModule {
 
+  @ActivityScoped
   @Provides
   internal fun provideViewContainer(): ViewContainer {
     return ViewContainer.DEFAULT


### PR DESCRIPTION
Accidentally misunderstood an error message during the migration and thought these were getting implicitly applied. That would be weird. Turns out they're not, and thus Hilt is not actually weird about this. Oops