### PR TITLE
Update Moshi to 1.10.0

### DIFF
--- a/app/src/main/kotlin/io/sweers/catchup/data/DataModule.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/data/DataModule.kt
@@ -20,7 +20,6 @@ import android.content.SharedPreferences
 import android.os.Looper
 import com.jakewharton.shimo.ObjectOrderRandomizer
 import com.serjltt.moshi.adapters.Wrapped
-import io.sweers.catchup.data.adapters.ArrayMapJsonAdapter
 import com.squareup.moshi.Moshi
 import dagger.Module
 import dagger.Provides
@@ -30,6 +29,7 @@ import dagger.multibindings.Multibinds
 import dev.zacsweers.catchup.appconfig.AppConfig
 import io.reactivex.schedulers.Schedulers
 import io.sweers.catchup.data.adapters.ArrayCollectionJsonAdapter
+import io.sweers.catchup.data.adapters.ArrayMapJsonAdapter
 import io.sweers.catchup.gemoji.GemojiModule
 import io.sweers.catchup.injection.DaggerSet
 import io.sweers.catchup.injection.SharedPreferencesName

--- a/app/src/main/kotlin/io/sweers/catchup/data/DataModule.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/data/DataModule.kt
@@ -20,7 +20,7 @@ import android.content.SharedPreferences
 import android.os.Looper
 import com.jakewharton.shimo.ObjectOrderRandomizer
 import com.serjltt.moshi.adapters.Wrapped
-import com.squareup.moshi.ArrayMapJsonAdapter
+import io.sweers.catchup.data.adapters.ArrayMapJsonAdapter
 import com.squareup.moshi.Moshi
 import dagger.Module
 import dagger.Provides

--- a/app/src/main/kotlin/io/sweers/catchup/data/adapters/ArrayCollectionJsonAdapter.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/data/adapters/ArrayCollectionJsonAdapter.kt
@@ -50,7 +50,7 @@ abstract class ArrayCollectionJsonAdapter<C : MutableCollection<T>, T> private c
   }
 
   override fun toString(): String {
-    return elementAdapter.toString() + ".collection()"
+    return "$elementAdapter.collection()"
   }
 
   companion object {
@@ -72,7 +72,7 @@ abstract class ArrayCollectionJsonAdapter<C : MutableCollection<T>, T> private c
       val elementAdapter = moshi.adapter<T>(elementType)
       return object : ArrayCollectionJsonAdapter<MutableCollection<T>, T>(elementAdapter) {
         override fun newCollection(): MutableCollection<T> {
-          return ArraySet()
+          return ArrayList()
         }
       }
     }

--- a/app/src/main/kotlin/io/sweers/catchup/data/adapters/ArrayCollectionJsonAdapter.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/data/adapters/ArrayCollectionJsonAdapter.kt
@@ -59,9 +59,9 @@ abstract class ArrayCollectionJsonAdapter<C : MutableCollection<T>, T> private c
       if (annotations.isEmpty()) {
         val rawType = Types.getRawType(type)
         if (rawType.isAssignableFrom(Set::class.java)) {
-          newSetAdapter<Any>(type, moshi).nullSafe()
+          return@Factory newSetAdapter<Any>(type, moshi).nullSafe()
         } else if (rawType.isAssignableFrom(Collection::class.java)) {
-          newListAdapter<Any>(type, moshi).nullSafe()
+          return@Factory newListAdapter<Any>(type, moshi).nullSafe()
         }
       }
       null

--- a/app/src/main/kotlin/io/sweers/catchup/data/adapters/ArrayMapJsonAdapter.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/data/adapters/ArrayMapJsonAdapter.kt
@@ -25,15 +25,14 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
-import java.util.Properties
 
 /**
  * Converts maps with string keys to JSON objects.
  */
 class ArrayMapJsonAdapter<K, V>(
-    moshi: Moshi,
-    keyType: Type,
-    valueType: Type
+  moshi: Moshi,
+  keyType: Type,
+  valueType: Type
 ) : JsonAdapter<Map<K, V>>() {
 
   private val keyAdapter = moshi.adapter<K>(keyType)
@@ -62,7 +61,7 @@ class ArrayMapJsonAdapter<K, V>(
       val replaced = result.put(name, value)
       if (replaced != null) {
         throw JsonDataException(
-            "Map key '$name' has multiple values at path ${reader.path}"
+          "Map key '$name' has multiple values at path ${reader.path}"
         )
       }
     }

--- a/app/src/main/kotlin/io/sweers/catchup/data/adapters/ArrayMapJsonAdapter.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/data/adapters/ArrayMapJsonAdapter.kt
@@ -80,7 +80,7 @@ class ArrayMapJsonAdapter<K, V>(
         val rawType = Types.getRawType(type)
         if (rawType == Map::class.java) {
           val keyAndValue = type.actualTypeArguments
-          ArrayMapJsonAdapter<Any, Any>(moshi, keyAndValue[0], keyAndValue[1]).nullSafe()
+          return@Factory ArrayMapJsonAdapter<Any, Any>(moshi, keyAndValue[0], keyAndValue[1]).nullSafe()
         }
       }
       null

--- a/app/src/test/kotlin/io/sweers/catchup/data/adapters/ArrayCollectionsJsonAdapterTest.kt
+++ b/app/src/test/kotlin/io/sweers/catchup/data/adapters/ArrayCollectionsJsonAdapterTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2020. Zac Sweers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.sweers.catchup.data.adapters
+
+import androidx.collection.ArraySet
+import com.google.common.truth.Truth.assertThat
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import org.junit.Test
+
+class ArrayCollectionsJsonAdapterTest {
+  @Test
+  fun testList() {
+    val moshi = Moshi.Builder()
+      .add(ArrayCollectionJsonAdapter.FACTORY)
+      .build()
+    val collection = listOf("one", "two", "three")
+    val adapter = moshi.adapter<List<String>>(Types.newParameterizedType(List::class.java, String::class.java))
+    val jsonString = adapter.toJson(collection)
+    assertThat(jsonString).isEqualTo("[\"one\",\"two\",\"three\"]")
+    val parsedMap = adapter.fromJson(jsonString)
+    assertThat(parsedMap).isEqualTo(collection)
+    assertThat(parsedMap).isInstanceOf(ArrayList::class.java)
+  }
+
+  @Test
+  fun testSet() {
+    val moshi = Moshi.Builder()
+      .add(ArrayCollectionJsonAdapter.FACTORY)
+      .build()
+    val collection = setOf("one", "two", "three")
+    val adapter = moshi.adapter<Set<String>>(Types.newParameterizedType(Set::class.java, String::class.java))
+    val jsonString = adapter.toJson(collection)
+    assertThat(jsonString).isEqualTo("[\"one\",\"two\",\"three\"]")
+    val parsedMap = adapter.fromJson(jsonString)
+    assertThat(parsedMap).isEqualTo(collection)
+    assertThat(parsedMap).isInstanceOf(ArraySet::class.java)
+  }
+}

--- a/app/src/test/kotlin/io/sweers/catchup/data/adapters/ArrayMapJsonAdapterTest.kt
+++ b/app/src/test/kotlin/io/sweers/catchup/data/adapters/ArrayMapJsonAdapterTest.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2020. Zac Sweers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.sweers.catchup.data.adapters
+
+import androidx.collection.ArrayMap
+import com.google.common.truth.Truth.assertThat
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import org.junit.Test
+
+class ArrayMapJsonAdapterTest {
+  @Test
+  fun testMap() {
+    val moshi = Moshi.Builder()
+      .add(ArrayMapJsonAdapter.FACTORY)
+      .build()
+    val map = mapOf("1" to "2", "3" to "4")
+    val adapter = moshi.adapter<Map<String, String>>(Types.newParameterizedType(Map::class.java, String::class.java, String::class.java))
+    val jsonString = adapter.toJson(map)
+    assertThat(jsonString).isEqualTo("{\"1\":\"2\",\"3\":\"4\"}")
+    val parsedMap = adapter.fromJson(jsonString)
+    assertThat(parsedMap).isEqualTo(map)
+    assertThat(parsedMap).isInstanceOf(ArrayMap::class.java)
+  }
+}

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -27,14 +27,13 @@ kotlinDslPluginOptions {
 object SharedBuildVersions {
   const val agp = "4.2.0-alpha08"
   const val kotlin = "1.4.0"
-  const val moshi = "1.9.3"
+  const val moshi = "1.10.0"
   const val okio = "2.8.0"
   const val kotlinJvmTarget = "1.8"
   val kotlinCompilerArgs = listOf(
       "-progressive",
       "-Xinline-classes",
       "-Xjsr305=strict",
-      "-Xassertions=jvm",
       "-Xopt-in=kotlin.contracts.ExperimentalContracts",
       "-Xopt-in=kotlin.experimental.ExperimentalTypeInference",
       "-Xopt-in=kotlin.ExperimentalStdlibApi",


### PR DESCRIPTION
This allows moving the arraymap adapter out of the package-private access