### PR TITLE
Use autogenerate id to persist increment across pages

### DIFF
--- a/app/schemas/io.sweers.catchup.data.CatchUpDatabase/6.json
+++ b/app/schemas/io.sweers.catchup.data.CatchUpDatabase/6.json
@@ -2,12 +2,18 @@
   "formatVersion": 1,
   "database": {
     "version": 6,
-    "identityHash": "a1a59fe418a844618e3c973a8bab0f2c",
+    "identityHash": "fc3fddbd02e78fdaaa4793d85090497a",
     "entities": [
       {
         "tableName": "items",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `title` TEXT, `timestamp` INTEGER, `serviceId` TEXT, `indexInResponse` INTEGER NOT NULL, `score` TEXT, `tag` TEXT, `author` TEXT, `source` TEXT, `itemClickUrl` TEXT, `detailKey` TEXT, `value` TEXT, `type` TEXT, `url` TEXT, `detailUrl` TEXT, `animatable` INTEGER, `sourceUrl` TEXT, `bestSize` TEXT, `imageId` TEXT, `text` TEXT, `textPrefix` TEXT, `icon` INTEGER, `clickUrl` TEXT, `iconTintColor` INTEGER, `formatTextAsCount` INTEGER, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`generatedId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` INTEGER NOT NULL, `title` TEXT, `timestamp` INTEGER, `serviceId` TEXT, `indexInResponse` INTEGER NOT NULL, `score` TEXT, `tag` TEXT, `author` TEXT, `source` TEXT, `itemClickUrl` TEXT, `detailKey` TEXT, `value` TEXT, `type` TEXT, `url` TEXT, `detailUrl` TEXT, `animatable` INTEGER, `sourceUrl` TEXT, `bestSize` TEXT, `imageId` TEXT, `text` TEXT, `textPrefix` TEXT, `icon` INTEGER, `clickUrl` TEXT, `iconTintColor` INTEGER, `formatTextAsCount` INTEGER)",
         "fields": [
+          {
+            "fieldPath": "generatedId",
+            "columnName": "generatedId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
           {
             "fieldPath": "id",
             "columnName": "id",
@@ -161,9 +167,9 @@
         ],
         "primaryKey": {
           "columnNames": [
-            "id"
+            "generatedId"
           ],
-          "autoGenerate": false
+          "autoGenerate": true
         },
         "indices": [],
         "foreignKeys": []
@@ -198,7 +204,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a1a59fe418a844618e3c973a8bab0f2c')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'fc3fddbd02e78fdaaa4793d85090497a')"
     ]
   }
 }

--- a/app/src/main/kotlin/io/sweers/catchup/data/ServiceDao.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/data/ServiceDao.kt
@@ -28,7 +28,7 @@ interface ServiceDao {
   @Insert(onConflict = OnConflictStrategy.REPLACE)
   suspend fun insertAll(posts: List<CatchUpItem>)
 
-  @Query("SELECT * FROM items WHERE serviceId = :serviceId ORDER BY indexInResponse ASC")
+  @Query("SELECT * FROM items WHERE serviceId = :serviceId ORDER BY generatedId ASC")
   fun itemsByService(serviceId: String): PagingSource<Int, CatchUpItem>
 
   @Query("DELETE FROM items WHERE serviceId = :serviceId")

--- a/service-api/src/main/kotlin/io/sweers/catchup/service/api/CatchUpItem.kt
+++ b/service-api/src/main/kotlin/io/sweers/catchup/service/api/CatchUpItem.kt
@@ -24,7 +24,8 @@ import kotlinx.datetime.Instant
 @Keep
 @Entity(tableName = "items")
 data class CatchUpItem(
-  @PrimaryKey val id: Long,
+  @PrimaryKey(autoGenerate = true) val generatedId: Int = 0,
+  val id: Long,
   val title: String,
   val timestamp: Instant?,
   val serviceId: String,


### PR DESCRIPTION
Here's how to fix the shuffling - you probably don't want to merge this and do something nicer instead, but hopefully this shows the idea.

Basically PagingSource results are sorted by `indexInResponse` which resets for each page, so we're loading
```
remote REFRESH -> [0, 1, 2]
<invalidate>
local REFRESH [0, 1, 2]
remote APPEND -> [0, 1, 2]
<invalidate>
local REFRESH [0, 0, 1, 1, 2, 2]
```