### PR TITLE
Repro lint issue

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 accompanist = "0.35.0-alpha"
-agp = "8.4.0-alpha10"
+agp = "8.3.0-rc02"
 androidx-activity = "1.9.0-alpha03"
 androidx-core = "1.13.0-alpha05"
 androidx-sqlite = "2.4.0"

--- a/libraries/http-api/build.gradle.kts
+++ b/libraries/http-api/build.gradle.kts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024 Zac Sweers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.sgp.base)
+}
+
+dependencies {
+  api(libs.okhttp.core)
+
+  testImplementation(libs.kotlin.test)
+  testImplementation(libs.test.junit)
+  testImplementation(libs.test.truth)
+  testImplementation("org.mockito:mockito-core:5.10.0")
+}

--- a/libraries/http-api/src/main/java/catchup/repro/HttpClient.kt
+++ b/libraries/http-api/src/main/java/catchup/repro/HttpClient.kt
@@ -1,0 +1,9 @@
+package catchup.repro
+
+import java.io.File
+import okhttp3.OkHttpClient
+
+abstract class HttpClient
+internal constructor(protected val client: OkHttpClient, protected val defaultDownloadsPath: File) {
+
+}

--- a/libraries/http-api/src/test/java/catchup/repro/ApiRxAdapterTest.java
+++ b/libraries/http-api/src/test/java/catchup/repro/ApiRxAdapterTest.java
@@ -1,0 +1,15 @@
+package catchup.repro;
+
+import static org.mockito.Mockito.mock;
+
+import org.junit.Before;
+
+public class ApiRxAdapterTest {
+
+  private HttpClient httpClientMock;
+
+  @Before
+  public void setUp() {
+    httpClientMock = mock(HttpClient.class);
+  }
+}

--- a/settings-all.gradle.kts
+++ b/settings-all.gradle.kts
@@ -14,6 +14,7 @@ include(
   ":libraries:gemoji",
   ":libraries:gemoji:db",
   ":libraries:gemoji:generator",
+  ":libraries:http-api",
   ":libraries:flowbinding",
   ":libraries:kotlinutil",
   ":libraries:retrofitconverters",


### PR DESCRIPTION
For https://issuetracker.google.com/issues/325564559

Run `./gradlew :libraries:http-api:lint`, yields a failure like this https://scans.gradle.com/s/5drjzglmu3cve