### PR TITLE
Remove deprecated `lifecycle.extensions`

### DIFF
--- a/app-scaffold/build.gradle.kts
+++ b/app-scaffold/build.gradle.kts
@@ -125,7 +125,6 @@ dependencies {
   implementation(libs.androidx.datastore.preferences.core)
   implementation(libs.androidx.design)
   implementation(libs.androidx.emojiAppcompat)
-  implementation(libs.androidx.lifecycle.extensions)
   implementation(libs.androidx.lifecycle.ktx)
   implementation(libs.androidx.paging.compose)
   implementation(libs.androidx.palette)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -114,7 +114,6 @@ androidx-paletteKtx = "androidx.palette:palette-ktx:1.0.0"
 androidx-preference = { module = "androidx.preference:preference", version.ref = "preferences" }
 androidx-preferenceKtx = { module = "androidx.preference:preference-ktx", version = "1.2.1" }
 
-androidx-lifecycle-extensions = "androidx.lifecycle:lifecycle-extensions:2.2.0"
 androidx-lifecycle-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }
 
 androidx-sqlite-framework = { module = "androidx.sqlite:sqlite-framework", version.ref = "androidx-sqlite" }


### PR DESCRIPTION
* Lifecycle Extensions have been deprecated for years, and no new artefacts are published.
* The project includes `lifecycle.extension` but does not use any of its methods. it is safe to remove.
* Please see [b/326451280](https://issuetracker.google.com/issues/326451280) for more details.